### PR TITLE
feat: nest building cost (nutrient-14, life-2)

### DIFF
--- a/openspec/specs/monster-lifecycle/spec.md
+++ b/openspec/specs/monster-lifecycle/spec.md
@@ -104,10 +104,13 @@ A Lizardman SHALL construct a nest when it finds a suitable open space.
 - **WHEN** a Lizardman is at a position where a contiguous 2x3 or 3x2 empty space exists containing that position
 - **THEN** it SHALL establish a nest, recording the nest area (6 cells)
 
-#### Scenario: Nest cost (FUTURE)
+#### Scenario: Nest cost
 - **WHEN** a Lizardman builds a nest
 - **THEN** it SHALL consume NEST_NUTRIENT_COST (14) nutrients and NEST_LIFE_COST (2) life
-- **NOTE**: Not yet implemented. Currently nests are free. Planned for a future change.
+
+#### Scenario: Nest affordability
+- **WHEN** a Lizardman has carryingNutrient < NEST_NUTRIENT_COST OR life <= NEST_LIFE_COST
+- **THEN** it SHALL NOT establish a nest and SHALL continue using straight movement fallback
 
 #### Scenario: Shared nests (FUTURE)
 - **WHEN** a Lizardman encounters another Lizardman's nest

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -84,3 +84,7 @@ export const LAYING_NUTRIENT_THRESHOLD = 5 // normal/nesting → laying: carryin
 export const LAYING_LIFE_THRESHOLD = 40 // normal/nesting → laying: life >= threshold
 export const LAYING_DURATION = 15 // laying → egg spawn: ticks to wait
 export const EGG_HATCH_DURATION = 20 // egg → hatch: ticks to wait
+
+// Nest building cost
+export const NEST_NUTRIENT_COST = 14   // nutrients consumed when building a nest
+export const NEST_LIFE_COST = 2        // life consumed when building a nest

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -35,6 +35,8 @@ export {
   LAYING_LIFE_THRESHOLD,
   LAYING_DURATION,
   EGG_HATCH_DURATION,
+  NEST_NUTRIENT_COST,
+  NEST_LIFE_COST,
 } from './constants'
 export type { MonsterConfig } from './constants'
 
@@ -84,6 +86,7 @@ export {
   generateMonsterId,
   attackMonster,
   processPhaseTransitions,
+  processNestEstablishment,
 } from './simulation'
 
 // Game Loop

--- a/src/core/movement/stationary.test.ts
+++ b/src/core/movement/stationary.test.ts
@@ -10,6 +10,7 @@ import {
   getDirectionToward,
   calculateStationaryMove,
 } from './stationary'
+import { NEST_NUTRIENT_COST, NEST_LIFE_COST } from '../constants'
 
 function createGrid(width: number, height: number, type: Cell['type'] = 'empty'): Cell[][] {
   return Array.from({ length: height }, () =>
@@ -228,7 +229,7 @@ describe('Stationary Movement', () => {
   describe('calculateStationaryMove', () => {
     it('should establish nest in open area and stay in place', () => {
       const grid = createGrid(8, 8, 'empty')
-      const monster = createMonster({ position: { x: 3, y: 3 }, nestPosition: null })
+      const monster = createMonster({ position: { x: 3, y: 3 }, nestPosition: null, carryingNutrient: NEST_NUTRIENT_COST, life: NEST_LIFE_COST + 1 })
 
       const result = calculateStationaryMove(monster, grid, [], () => 0)
 
@@ -236,6 +237,36 @@ describe('Stationary Movement', () => {
       expect(result.nestPosition).not.toBeNull()
       expect(result.nestOrientation).not.toBeNull()
       expect(result.position).toEqual({ x: 3, y: 3 }) // stays in place when establishing
+    })
+
+    it('should NOT establish nest when carryingNutrient < NEST_NUTRIENT_COST', () => {
+      const grid = createGrid(8, 8, 'empty')
+      const monster = createMonster({
+        position: { x: 3, y: 3 },
+        nestPosition: null,
+        carryingNutrient: 5,
+        life: 80,
+      })
+
+      const result = calculateStationaryMove(monster, grid, [], () => 0)
+
+      // Should fall back to straight movement, not establish nest
+      expect(result.nestPosition).toBeNull()
+    })
+
+    it('should NOT establish nest when life <= NEST_LIFE_COST', () => {
+      const grid = createGrid(8, 8, 'empty')
+      const monster = createMonster({
+        position: { x: 3, y: 3 },
+        nestPosition: null,
+        carryingNutrient: NEST_NUTRIENT_COST,
+        life: NEST_LIFE_COST,
+      })
+
+      const result = calculateStationaryMove(monster, grid, [], () => 0)
+
+      // Should fall back to straight movement, not establish nest
+      expect(result.nestPosition).toBeNull()
     })
 
     it('should patrol by moving one cell at a time', () => {

--- a/src/core/movement/stationary.ts
+++ b/src/core/movement/stationary.ts
@@ -1,7 +1,7 @@
 import type { Cell, Direction, Monster, Position } from '../types'
 import { getForwardPosition, getTurnDirections, isValidMove } from './straight'
 import { isHungry } from './hunger'
-import { LAYING_NUTRIENT_THRESHOLD, LAYING_LIFE_THRESHOLD } from '../constants'
+import { LAYING_NUTRIENT_THRESHOLD, LAYING_LIFE_THRESHOLD, NEST_NUTRIENT_COST, NEST_LIFE_COST } from '../constants'
 
 /**
  * Check if position is adjacent to nest (including diagonal)
@@ -363,7 +363,9 @@ export function calculateStationaryMove(
   // No nest yet - try to establish one
   if (monster.nestPosition === null) {
     const nestInfo = findNestArea(monster.position, grid)
-    if (nestInfo) {
+    if (nestInfo &&
+        monster.carryingNutrient >= NEST_NUTRIENT_COST &&
+        monster.life > NEST_LIFE_COST) {
       // Establish nest, record center and orientation
       return {
         position: monster.position,

--- a/src/core/simulation.test.ts
+++ b/src/core/simulation.test.ts
@@ -6,6 +6,7 @@ import {
   applyMovements,
   decreaseLifeForMoved,
   processNutrientInteractions,
+  processNestEstablishment,
   tick,
   dig,
   isAdjacentToEmpty,
@@ -22,6 +23,8 @@ import {
   PUPA_NUTRIENT_THRESHOLD,
   PUPA_DURATION,
   EGG_HATCH_DURATION,
+  NEST_NUTRIENT_COST,
+  NEST_LIFE_COST,
 } from './constants'
 import { getTotalNutrients } from './nutrient'
 
@@ -1224,6 +1227,67 @@ describe('Simulation', () => {
           expect(result.state.monsters[0].carryingNutrient).toBe(10)
         }
       })
+    })
+  })
+
+  describe('processNestEstablishment', () => {
+    it('should deduct nutrient and life cost when nest is newly established (null → non-null)', () => {
+      const monster = createMonster({
+        id: 'liz-1',
+        type: 'lizardman',
+        life: 60,
+        maxLife: 80,
+        carryingNutrient: 20,
+        nestPosition: { x: 3, y: 3 },
+        nestOrientation: 'horizontal',
+      })
+
+      const originalNestPositions = new Map<string, { x: number; y: number } | null>()
+      originalNestPositions.set('liz-1', null)
+
+      const result = processNestEstablishment([monster], originalNestPositions)
+
+      expect(result.monsters[0].carryingNutrient).toBe(20 - NEST_NUTRIENT_COST)
+      expect(result.monsters[0].life).toBe(60 - NEST_LIFE_COST)
+    })
+
+    it('should not deduct cost when nest was already established (non-null → non-null)', () => {
+      const monster = createMonster({
+        id: 'liz-2',
+        type: 'lizardman',
+        life: 60,
+        maxLife: 80,
+        carryingNutrient: 20,
+        nestPosition: { x: 3, y: 3 },
+        nestOrientation: 'horizontal',
+      })
+
+      const originalNestPositions = new Map<string, { x: number; y: number } | null>()
+      originalNestPositions.set('liz-2', { x: 3, y: 3 })
+
+      const result = processNestEstablishment([monster], originalNestPositions)
+
+      expect(result.monsters[0].carryingNutrient).toBe(20)
+      expect(result.monsters[0].life).toBe(60)
+    })
+
+    it('should not deduct cost for monsters without nest (null → null)', () => {
+      const monster = createMonster({
+        id: 'liz-3',
+        type: 'lizardman',
+        life: 60,
+        maxLife: 80,
+        carryingNutrient: 20,
+        nestPosition: null,
+      })
+
+      const originalNestPositions = new Map<string, { x: number; y: number } | null>()
+      originalNestPositions.set('liz-3', null)
+
+      const result = processNestEstablishment([monster], originalNestPositions)
+
+      expect(result.monsters[0].carryingNutrient).toBe(20)
+      expect(result.monsters[0].life).toBe(60)
     })
   })
 })

--- a/src/core/simulation.ts
+++ b/src/core/simulation.ts
@@ -13,6 +13,8 @@ import {
   EGG_HATCH_DURATION,
   MOVEMENT_LIFE_COST,
   MONSTER_CONFIGS,
+  NEST_NUTRIENT_COST,
+  NEST_LIFE_COST,
 } from './constants'
 import type {
   Cell,
@@ -169,6 +171,29 @@ export function applyMovements(plannedMoves: PlannedMove[]): { monsters: Monster
   }))
 
   return { monsters: movedMonsters }
+}
+
+/**
+ * Process nest establishment cost for lizardmen that just built a nest
+ */
+export function processNestEstablishment(
+  monsters: Monster[],
+  originalNestPositions: Map<string, Position | null>
+): { monsters: Monster[]; events: GameEvent[] } {
+  const events: GameEvent[] = []
+  const updated = monsters.map(monster => {
+    const originalNest = originalNestPositions.get(monster.id)
+    if (originalNest === null && monster.nestPosition !== null) {
+      // Nest newly established - deduct cost
+      return {
+        ...monster,
+        carryingNutrient: monster.carryingNutrient - NEST_NUTRIENT_COST,
+        life: monster.life - NEST_LIFE_COST,
+      }
+    }
+    return monster
+  })
+  return { monsters: updated, events }
 }
 
 /**
@@ -672,6 +697,12 @@ export function tick(
     originalPositions.set(monster.id, { ...monster.position })
   }
 
+  // Save original nest positions for nest establishment detection
+  const originalNestPositions = new Map<string, Position | null>()
+  for (const monster of state.monsters) {
+    originalNestPositions.set(monster.id, monster.nestPosition)
+  }
+
   // 1. Calculate all moves
   const plannedMoves = calculateAllMoves(state, randomFn)
 
@@ -681,8 +712,12 @@ export function tick(
   // 3. Apply movements
   const moveResult = applyMovements(resolvedMoves)
 
+  // 3.5. Process nest establishment cost
+  const nestResult = processNestEstablishment(moveResult.monsters, originalNestPositions)
+  allEvents.push(...nestResult.events)
+
   // 4. Process predation (same cell)
-  const predationResult = processPredation(moveResult.monsters, state.grid)
+  const predationResult = processPredation(nestResult.monsters, state.grid)
   allEvents.push(...predationResult.events)
 
   // 5. Process nutrient absorption/release for Nijirigoke (before life decrease)


### PR DESCRIPTION
## Summary
- Lizardman nest establishment now costs 14 nutrients and 2 life (matching original game)
- Prevents newly hatched lizardmen from immediately building nests (child has ~5 nutrients, needs 14)
- Affordability gate in movement layer + cost deduction in simulation layer

## Test plan
- [x] 201 tests pass (5 new tests for nest cost)
- [x] Lint clean
- [x] CLI scenario confirms child lizardman cannot build nest with 5 nutrients