### PR TITLE
perf(test): switch core tests from jsdom to node environment

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,12 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: 'node',
     include: ['src/**/*.{test,spec}.{js,ts}', 'tests/**/*.{test,spec}.{js,ts}'],
+    environmentMatchGlobs: [
+      ['tests/**', 'jsdom'],
+      ['src/**/*.vue.test.*', 'jsdom'],
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Core tests are pure logic with no DOM dependency. Switching from jsdom to node environment eliminates 6s overhead.