### PR TITLE
docs: add testing and versioning rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "src/**/*.ts"
+  - "src/**/*.vue"
+---
+
+# テスト検証ルール
+
+## 実装時の必須検証
+
+1. **テスト実行**: 実装後は必ず `docker compose run --rm app pnpm test` で全テスト通過を確認
+2. **lint**: `docker compose run --rm app pnpm lint` でエラーがないこと
+3. **ブラウザ動作確認**: UI変更時は `docker compose up` でブラウザから実際にプレイして動作確認。スクリーンショットやコンソールログで検証する
+4. **staleファイル注意**: `.js`, `.d.ts` がsrc/以下に残っているとViteが誤って読み込む。`find src -name "*.js" -o -name "*.d.ts"` で確認し、あれば削除
+
+## TDD
+
+- テストを先に書く（RED） → 最小実装（GREEN） → リファクタ
+- Agent Teamsで並列実装する場合も、各チームメイトがTDDサイクルを守ること
+
+## コミット前チェックリスト
+
+- [ ] 全テスト通過
+- [ ] lint通過
+- [ ] UI変更がある場合、ブラウザで動作確認済み
+- [ ] stale .js/.d.ts ファイルがないこと

--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -1,0 +1,22 @@
+# バージョン管理ルール
+
+## Semantic Versioning
+
+`vMAJOR.MINOR.PATCH` (v1.0.0未満は開発版)
+
+- **MINOR**: 新機能追加（例: 勇者システム導入 → v0.1.0 → v0.2.0）
+- **PATCH**: バグ修正・調整（例: 即スポーン修正 → v0.1.1）
+
+## マージ後のタグ付け
+
+PRがmainにマージされたら:
+
+1. `git checkout main && git pull`
+2. 変更内容に応じて MINOR or PATCH を判断
+3. `git tag vX.Y.Z && git push --tags`
+
+## PRとの対応
+
+- 機能PR（feature/）→ MINOR バンプ
+- 修正PR（fix/）→ PATCH バンプ
+- 複数PRをまとめてタグ付けしない。各マージごとにタグを打つ

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ playwright/.cache/
 !.claude/skills/
 !.claude/hooks/
 !.claude/agents/
+!.claude/rules/
 !.claude/settings.json
 
 # pnpm


### PR DESCRIPTION
## Summary
- `.claude/rules/testing.md`: TDD・ブラウザ検証・staleファイル注意・コミット前チェックリスト
- `.claude/rules/versioning.md`: Semantic Versioning・マージ後タグ付けポリシー
- `.gitignore`: `.claude/rules/` をgit追跡対象に追加

## Test plan
- [ ] CI通過（ドキュメントのみの変更）