### PR TITLE
feat(ci): add E2E tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,22 @@ jobs:
 
       - name: Type check
         run: pnpm exec vue-tsc -b
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: pnpm e2e

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,6 +35,7 @@ services:
       - .:/app
     environment:
       - CI=true
+      - DOCKER=true
     command: sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm exec playwright test --reporter=list"
     depends_on:
       - app

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,11 +8,16 @@ export default defineConfig({
   workers: 1,
   reporter: 'list',
   use: {
-    // Use Docker service name when running in container, localhost otherwise
-    baseURL: process.env.CI ? 'http://app:5173' : 'http://localhost:5173',
+    // Docker container uses service name 'app', otherwise localhost
+    baseURL: process.env.DOCKER ? 'http://app:5173' : 'http://localhost:5173',
     trace: 'on-first-retry',
     headless: true,
     ignoreHTTPSErrors: true,
+  },
+  webServer: {
+    command: 'pnpm dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary
- `playwright.config.ts` に `webServer` 設定追加（CI上でVite自動起動）
- `baseURL` のDocker判定を `CI` → `DOCKER` 環境変数に変更（GitHub ActionsもCI=trueのため）
- `.github/workflows/ci.yml` に `e2e` ジョブ追加（Playwright chromiumインストール + テスト実行）
- `compose.yaml` e2eサービスに `DOCKER=true` 環境変数追加

Closes #30

## Test plan
- [ ] CI e2eジョブが通る
- [ ] ローカル Docker E2E引き続き動作