### PR TITLE
fix(core): nijirigoke withered phase minimum duration

### DIFF
--- a/e2e/nijirigoke-scenario.spec.ts
+++ b/e2e/nijirigoke-scenario.spec.ts
@@ -46,7 +46,7 @@ test.describe('Nijirigoke Scenario E2E Tests', () => {
     expect(phaseTickCounts.mobile, 'mobile phase should last more than 1 tick').toBeGreaterThan(1)
     expect(phaseTickCounts.bud, 'bud phase should last more than 1 tick').toBeGreaterThan(1)
     expect(phaseTickCounts.flower, 'flower phase should last more than 1 tick').toBeGreaterThan(1)
-    expect(phaseTickCounts.withered, 'withered phase should be observed').toBeGreaterThanOrEqual(1)
+    expect(phaseTickCounts.withered, 'withered phase should last more than 1 tick').toBeGreaterThan(1)
   })
 
   test('Full phase progression: mobile → bud → flower → withered', async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -44,6 +44,7 @@ export interface MonsterTypeConfig {
   budNutrientThreshold?: number
   budLifeThreshold?: number
   minMobileTicks?: number
+  minWitheredTicks?: number
   flowerNutrientThreshold?: number
   moyomoyoDamage?: number
   // Gajigajimushi lifecycle
@@ -113,6 +114,7 @@ export function createDefaultConfig(): GameConfig {
         budNutrientThreshold: BUD_NUTRIENT_THRESHOLD,
         budLifeThreshold: BUD_LIFE_THRESHOLD,
         minMobileTicks: 8,
+        minWitheredTicks: 3,
         flowerNutrientThreshold: FLOWER_NUTRIENT_THRESHOLD,
         moyomoyoDamage: MOYOMOYO_DAMAGE,
       },

--- a/src/core/phase-transitions.ts
+++ b/src/core/phase-transitions.ts
@@ -227,7 +227,16 @@ function processNijirigokePhase(
     return { monster: { ...monster, life: newLife }, grid }
   }
 
-  // withered: reproduce (spawn up to 5 offspring, distribute nutrients evenly)
+  // withered: wait minWitheredTicks, then reproduce
+  if (phase === 'withered') {
+    const minWitheredTicks = nijiConfig.minWitheredTicks ?? 0
+    const updatedCounter = monster.phaseTickCounter + 1
+
+    if (updatedCounter < minWitheredTicks) {
+      return { monster: { ...monster, phaseTickCounter: updatedCounter }, grid }
+    }
+  }
+
   if (phase === 'withered' && monster.carryingNutrient > 0) {
     const maxOffspring = 5
     const surroundingCells = getSurroundingCells(monster.position, grid)

--- a/src/core/simulation.test.ts
+++ b/src/core/simulation.test.ts
@@ -1080,13 +1080,37 @@ describe('Simulation', () => {
         expect(result.monsters[0].life).toBe(0)
       })
 
-      it('should reproduce in withered phase and distribute nutrients', () => {
+      it('should NOT reproduce in withered phase before minWitheredTicks', () => {
         const grid = createGrid(5, 5, 'empty')
         const monster = createMonster({
           id: 'm1',
           type: 'nijirigoke',
           position: { x: 2, y: 2 },
           phase: 'withered',
+          phaseTickCounter: 0, // below minWitheredTicks
+          life: 0,
+          carryingNutrient: 10,
+        })
+        const state = createGameState({ grid, monsters: [monster] })
+
+        const result = processPhaseTransitions(state)
+
+        // Parent should still be alive (not reproduced yet)
+        const parents = result.monsters.filter((m) => m.id === 'm1')
+        expect(parents).toHaveLength(1)
+        expect(parents[0].phase).toBe('withered')
+        expect(parents[0].phaseTickCounter).toBe(1) // incremented
+      })
+
+      it('should reproduce in withered phase after minWitheredTicks', () => {
+        const grid = createGrid(5, 5, 'empty')
+        const minWitheredTicks = 3 // default
+        const monster = createMonster({
+          id: 'm1',
+          type: 'nijirigoke',
+          position: { x: 2, y: 2 },
+          phase: 'withered',
+          phaseTickCounter: minWitheredTicks, // >= minWitheredTicks
           life: 0,
           carryingNutrient: 10,
         })
@@ -1218,7 +1242,7 @@ describe('Simulation', () => {
           id: 'niji-1',
           position: { x: 2, y: 2 },
           phase: 'withered',
-          phaseTickCounter: 0,
+          phaseTickCounter: 3, // >= minWitheredTicks
           carryingNutrient: 3,
           life: 0,
         })
@@ -1226,7 +1250,7 @@ describe('Simulation', () => {
           id: 'niji-2',
           position: { x: 6, y: 6 },
           phase: 'withered',
-          phaseTickCounter: 0,
+          phaseTickCounter: 3, // >= minWitheredTicks
           carryingNutrient: 3,
           life: 0,
         })
@@ -1249,7 +1273,7 @@ describe('Simulation', () => {
           id: 'niji-1',
           position: { x: 5, y: 5 },
           phase: 'withered',
-          phaseTickCounter: 0,
+          phaseTickCounter: 3, // >= minWitheredTicks
           carryingNutrient: 8,
           life: 0,
         })


### PR DESCRIPTION
## Summary
- `minWitheredTicks` (デフォルト: 3) を追加し、witheredフェーズの即時繁殖を防止
- `minMobileTicks` と同じパターンでphaseTickCounterチェック
- E2Eテストのwitheredアサーションを `>= 1` → `> 1` に強化

Closes #31

## Test plan
- [x] ユニットテスト: withered minTicks前に繁殖しないテスト追加 (287 passed)
- [x] E2Eテスト: withered > 1 tick確認 (12 passed)
- [x] lint通過