### PR TITLE
fix(docs): clarify diagram-spec inconsistencies

### DIFF
--- a/docs/diagrams/monster-lifecycle.md
+++ b/docs/diagrams/monster-lifecycle.md
@@ -1,4 +1,4 @@
-<!-- Based on: v0.4.2 -->
+<!-- Based on: v0.4.3 -->
 # モンスターライフサイクル
 
 ## ニジリゴケ（Nijirigoke）
@@ -96,12 +96,9 @@ stateDiagram-v2
 
     normal --> nesting: 巣を発見/構築
     nesting --> laying: 巣内 AND carryingNutrient ≥ LAYING_THRESHOLD\nAND life ≥ LAYING_LIFE_THRESHOLD
-    laying --> egg_created: LAYING_DURATION ticks経過
-    egg_created --> nesting: 親は通常に復帰
+    laying --> nesting: LAYING_DURATION ticks経過\n親はnestingに復帰
+    laying -.-> egg: 卵エンティティを別途生成
 
-    state egg_phase <<fork>>
-    egg_created --> egg_phase
-    egg_phase --> egg: 卵エンティティ生成
     egg --> hatched: EGG_HATCH_DURATION ticks経過
     hatched --> [*]: 新しいLizardman(normal)
 

--- a/docs/diagrams/nutrient-flow.md
+++ b/docs/diagrams/nutrient-flow.md
@@ -1,4 +1,4 @@
-<!-- Based on: v0.4.2 -->
+<!-- Based on: v0.4.3 -->
 # 養分フロー
 
 ## 養分循環の全体像
@@ -18,8 +18,8 @@ flowchart TD
     SOIL -->|"掘る（N > 0）"| DIG
     DIG -->|"モンスター生成\nlife = min(N, maxLife)\n余剰 = carryingNutrient"| MONSTER
     MONSTER -->|"捕食される"| PREDATION
-    PREDATION -->|"養分が捕食者へ移転"| MONSTER
-    MONSTER -->|"life ≤ 0"| DEATH
+    PREDATION -->|"養分が捕食者へ直接移転\n（グリッドに放出しない）"| MONSTER
+    MONSTER -->|"life ≤ 0\n（捕食以外の死亡）"| DEATH
     DEATH -->|"carryingNutrient\n9セルに均等分配"| CELLS
     CELLS -->|"土壌セルに蓄積"| SOIL
     SOIL -->|"隣接ニジリゴケが吸収"| ABSORB


### PR DESCRIPTION
## Summary
- monster-lifecycle: `<<fork>>` 記法を破線矢印に簡略化（卵は別エンティティ）
- nutrient-flow: 捕食時の直接移転と死亡時の9セル分配を明確に区別
- hero-system: 確認の結果修正不要（`demon-lord-flag/spec.md` に記載あり）

Closes #44

## Test plan
- [ ] GitHub上で monster-lifecycle.md の Mermaid レンダリング確認（破線矢印の表示）
- [ ] GitHub上で nutrient-flow.md のラベル表示確認