### PR TITLE
fix(spec): entrance cell becomes monster-impassable (closes #56)

### DIFF
--- a/openspec/changes/entrance-cell-impassable/proposal.md
+++ b/openspec/changes/entrance-cell-impassable/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+ユーザー指摘により、入口セル (entrance) はゆうなま原作と同じく「**勇者は通過できるが、モンスターは進入できない**」セマンティクスが期待されていることが判明した。
+
+現状の実装と spec (`hero-spawn` capability `Entrance cell type` scenario) は entrance を `type: 'empty'` で生成しており、結果としてモンスターは entrance を素通り可能になっている。spec ・実装ともに修正が必要。
+
+## What Changes
+
+### CellType の拡張
+
+- `src/core/types.ts` の `CellType` に `'entrance'` を追加 (`'soil' | 'empty' | 'wall' | 'entrance'`)
+- 入口セル (`entrancePosition`) は初期化時に `type: 'entrance'` で生成される (従来は `'empty'`)
+
+### モンスターの進入禁止 (実装変更ゼロで成立)
+
+`src/core/movement/straight.ts:23-27` の `isValidMove()` は `type === 'empty'` のみを通過可と判定する。本 change で `'entrance'` という新しい型を導入することで、上記ガードにより自動的にモンスターの進入を block する。**移動ロジック側の変更は不要**。
+
+### 勇者の挙動 (変更不要)
+
+勇者の spawn (`src/core/hero/spawn.ts`) と return path (`src/core/hero/ai.ts`) は `entrancePosition` を Position として直接参照しており、cell type のチェックを経由しない:
+- spawn: `hero.position = entrancePosition` (cell type 不問)
+- exploration: 勇者は entrance を visited から開始するため、自分から entrance に入ろうとしない
+- return: pathHistory を popping し、`hasMonsterAt` のみチェック (`isPassable` 不通過)
+
+つまり勇者の出入りは従来通り機能する。
+
+### 表示 (最小調整)
+
+- `src/components/grid-view-helpers.ts` の `getCellDisplay()` の switch 文は exhaustive。`case 'entrance': return '門'` を追加する (実際は `isEntranceCell` Position-based check が先に hit するため到達しないが、TypeScript 網羅性のため)
+- 既存の `entrance-cell` クラス (Position-based) と `.entrance-cell` スタイルはそのまま機能する
+
+### spec 変更 (MODIFIED)
+
+- `openspec/specs/hero-spawn/spec.md` の `Entrance cell type` scenario:
+  - 変更前: "the entrance cell SHALL be of type 'empty' (passable)"
+  - 変更後: "the entrance cell SHALL be of type 'entrance' (passable for heroes, impassable for monsters)"
+- 同 capability に新 Scenario を追加: `Monsters cannot enter entrance cell`
+
+### テスト
+
+- `src/core/movement/straight.test.ts`: `isValidMove` が `'entrance'` セルに対して false を返すユニットテストを追加
+- `src/components/GridView.test.ts`: parametric test に entrance cell の type=='entrance' 検証 + '門' 表示テストを追加
+- 既存 `simulation.test.ts` の `entrance cell is empty` test は新仕様に合わせ rename + 期待値更新済み (uncommitted で先行修正)
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hero-spawn`: `Entrance cell type` requirement を **`'empty'` → `'entrance'`** に変更し、新 scenario `Monsters cannot enter entrance cell` を追加
+
+### New Capabilities
+
+なし
+
+## Impact
+
+- **コード**
+  - `src/core/types.ts`: CellType に 'entrance' 追加 (1 行)
+  - `src/core/spawn.ts:75-76`: 入口セル初期化を `type: 'entrance'` に (2 行)
+  - `src/components/grid-view-helpers.ts`: switch に 'entrance' case 追加 (2 行)
+  - `src/core/movement/`, `src/core/predation.ts`, `src/core/hero/`, `src/App.vue` style: **変更不要**
+- **テスト**
+  - 追加: `straight.test.ts` の isValidMove (entrance) test 1 件
+  - 追加: `GridView.test.ts` parametric test 1 件
+  - 修正: `simulation.test.ts:911-912` の test 名 + 期待値 (uncommitted で先行)
+- **ユーザー視点の変化**
+  - large 30×40 などで生態系が画面上方の entrance に到達したとき、entrance に「居座って外に出る」モンスターが出なくなる
+  - 表示は変更なし (門 アイコン継続)
+- **後続 change**
+  - 既存 `hero-spawn` capability spec を本 change で MODIFIED するため、archive 後 main spec が更新される

--- a/openspec/changes/entrance-cell-impassable/specs/hero-spawn/spec.md
+++ b/openspec/changes/entrance-cell-impassable/specs/hero-spawn/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Entrance cell
+
+The system SHALL designate the top-center cell of the grid as the entrance. The entrance position SHALL be stored in `GameState.entrancePosition`. The entrance cell SHALL be of type `'entrance'` — passable for heroes (spawn / escape) but impassable for monsters.
+
+#### Scenario: Entrance position calculation
+
+- **WHEN** a grid of width W is initialized
+- **THEN** the entrance position SHALL be at (floor(W/2), 0)
+
+#### Scenario: Entrance cell type
+
+- **WHEN** the grid is initialized
+- **THEN** the entrance cell SHALL be of type `'entrance'`
+
+#### Scenario: Monsters cannot enter entrance cell
+
+- **WHEN** a monster's movement logic evaluates the entrance cell as a candidate destination
+- **THEN** the cell SHALL be rejected as invalid (because `isValidMove` only permits cells of type `'empty'`)
+- **AND** the monster SHALL NOT occupy the entrance cell at any point during a tick
+
+#### Scenario: Heroes pass through entrance cell
+
+- **WHEN** a hero spawns
+- **THEN** the hero SHALL be placed at `entrancePosition` regardless of the cell type at that position
+- **WHEN** a hero in `'returning'` state retraces its `pathHistory` to `entrancePosition`
+- **THEN** the hero SHALL reach the entrance and trigger `HERO_ESCAPED` (the cell type does not block this movement because the hero return path bypasses cell-type gating)

--- a/openspec/changes/entrance-cell-impassable/tasks.md
+++ b/openspec/changes/entrance-cell-impassable/tasks.md
@@ -1,0 +1,33 @@
+## 1. 実装
+
+- [x] **1.1** `src/core/types.ts`: CellType に `'entrance'` を追加
+- [x] **1.2** `src/core/spawn.ts:75-76`: 入口セル初期化を `type: 'entrance'` に変更
+- [x] **1.3** `src/components/grid-view-helpers.ts`: `getCellDisplay` の switch に `case 'entrance': return '門'` を追加
+- [x] **1.4** `src/core/simulation.test.ts:905-912`: 既存 `entrance cell is empty` テストを `entrance cell has type 'entrance'` に修正
+
+## 2. テスト追加
+
+- [x] **2.1** `src/core/movement/straight.test.ts`: `isValidMove` が `'entrance'` セルで false を返すテストを追加
+- [x] **2.2** `src/components/GridView.test.ts`: 各 grid サイズで entrance セルが `type === 'entrance'` を持ち '門' を表示するテストを追加 (parametric test 内)
+
+## 3. 検証
+
+- [x] **3.1** `pnpm test -- --run` で全テスト pass を確認 (342 件)
+- [x] **3.2** `pnpm lint` で lint クリーン
+- [x] **3.3** `pnpm exec vue-tsc -b` で型エラー無し
+
+## 4. spec 更新
+
+- [x] **4.1** delta spec (`openspec/changes/entrance-cell-impassable/specs/hero-spawn/spec.md`) 作成
+- [ ] **4.2** `openspec change validate entrance-cell-impassable` で validate
+
+## 5. PR / merge / tag / archive
+
+- [ ] **5.1** commit + push
+- [ ] **5.2** PR 作成 (closes #56)
+- [ ] **5.3** CI green 確認
+- [ ] **5.4** `gh pr merge --squash --delete-branch` で manual merge
+- [ ] **5.5** main pull → `git tag v0.5.1` → `git push --tags`
+- [ ] **5.6** `gh issue close 56`
+- [ ] **5.7** archive change (spec/archive ブランチ → archive PR → manual merge)
+- [ ] **5.8** worktree 削除

--- a/src/components/GridView.test.ts
+++ b/src/components/GridView.test.ts
@@ -166,4 +166,13 @@ describe.each([
     expect(emitted).toBeTruthy()
     expect(emitted?.[0]).toEqual([{ x: 1, y: 1 }])
   })
+
+  it("entrance cell has type 'entrance' in state and displays 門", () => {
+    const { gameState, config } = makeStateAtSize()
+    const entranceX = Math.floor(width / 2)
+    expect(gameState.grid[0][entranceX].type).toBe('entrance')
+    const wrapper = mount(GridView, { props: { gameState, config } })
+    const entranceCell = wrapper.findAll('.grid .row')[0].findAll('.cell')[entranceX]
+    expect(entranceCell.text()).toBe('門')
+  })
 })

--- a/src/components/grid-view-helpers.ts
+++ b/src/components/grid-view-helpers.ts
@@ -116,6 +116,8 @@ export function getCellDisplay(
       return '土'
     case 'empty':
       return '　'
+    case 'entrance':
+      return '門'
   }
 }
 

--- a/src/core/movement/straight.test.ts
+++ b/src/core/movement/straight.test.ts
@@ -77,6 +77,12 @@ describe('Straight Movement', () => {
       const grid = createGrid(5, 5, 'soil')
       expect(isValidMove({ x: 2, y: 2 }, grid)).toBe(false)
     })
+
+    it('should return false for entrance cell (monsters cannot enter the door)', () => {
+      const grid = createGrid(5, 5, 'empty')
+      grid[2][2].type = 'entrance'
+      expect(isValidMove({ x: 2, y: 2 }, grid)).toBe(false)
+    })
   })
 
   describe('getTurnDirections', () => {

--- a/src/core/simulation.test.ts
+++ b/src/core/simulation.test.ts
@@ -905,11 +905,11 @@ describe('Simulation', () => {
       expect(state.heroSpawnConfig.heroesSpawned).toBe(0)
     })
 
-    it('should ensure entrance cell is empty (heroes spawn here)', () => {
+    it('should ensure entrance cell has type "entrance" (heroes spawn here, monsters cannot enter)', () => {
       const state = createInitialGameState(20, 15)
 
       const entranceCell = state.grid[state.entrancePosition.y][state.entrancePosition.x]
-      expect(entranceCell.type).toBe('empty')
+      expect(entranceCell.type).toBe('entrance')
     })
 
     it('should not place demon lord by default', () => {

--- a/src/core/spawn.ts
+++ b/src/core/spawn.ts
@@ -72,8 +72,8 @@ export function createGameState(
     grid.push(row)
   }
 
-  // Make entrance cell empty (heroes spawn here, spec requires it to be empty)
-  grid[entrancePosition.y][entrancePosition.x] = { type: 'empty', nutrientAmount: 0, magicAmount: 0 }
+  // Entrance cell: heroes spawn/escape here, monsters cannot enter (isValidMove gates on type==='empty')
+  grid[entrancePosition.y][entrancePosition.x] = { type: 'entrance', nutrientAmount: 0, magicAmount: 0 }
 
   if (demonLordPosition) {
     grid[demonLordPosition.y][demonLordPosition.x] = { type: 'empty', nutrientAmount: 0, magicAmount: 0 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -38,7 +38,8 @@ export interface Monster {
 }
 
 // Cell types
-export type CellType = 'soil' | 'empty' | 'wall'
+// 'entrance': hero spawn/escape cell. Heroes can pass through; monsters cannot enter.
+export type CellType = 'soil' | 'empty' | 'wall' | 'entrance'
 
 // Grid cell
 export interface Cell {


### PR DESCRIPTION
Closes #56

## Summary

ユーザー指摘により、入口セル (門マス) は原作 (ゆうなま) と同じく**モンスターが進入できない**セマンティクスが期待されていた。`entrance` を新しい `CellType` として導入することで、既存の `isValidMove` (`type === 'empty'` のみ通過可) によりモンスターは自動的に block される。勇者は `entrancePosition` を Position として直接参照する spawn / escape 経路で従来通り通行可能。

## Changes

- `src/core/types.ts`: `CellType` に `'entrance'` を追加
- `src/core/spawn.ts:75-76`: 入口セル初期化を `type: 'entrance'` に変更 (従来は `'empty'`)
- `src/components/grid-view-helpers.ts`: `getCellDisplay` switch に `case 'entrance': return '門'` (TS exhaustiveness)
- 新テスト: `isValidMove(entrance) === false` (`straight.test.ts`), entrance セルが `type === 'entrance'` で `'門'` を表示する (`GridView.test.ts` parametric)
- spec: `hero-spawn` capability の `Entrance cell type` requirement を `'empty'` → `'entrance'` に MODIFIED + `Monsters cannot enter entrance cell` scenario 追加

## 影響なしのもの

- 移動ロジック (`movement/`)、捕食 (`predation.ts`)、勇者 AI (`hero/`)、App.vue style: **変更なし** (isValidMove ガード + Position-based 勇者ロジックでカバー)

## Test plan

- [x] `pnpm test -- --run`: 342 件 pass
- [x] `pnpm lint`: クリーン
- [x] `pnpm exec vue-tsc -b`: 型エラー無し
- [x] `openspec validate entrance-cell-impassable --strict`: pass
- [ ] CI green

## Followup

- merge 後 `v0.5.1` tag、archive
