### PR TITLE
refactor(App.vue): Phase 2 — extract scenarios + state builders + CSS (closes #57)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,425 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 20px;
+  background: #1a1a1a;
+  color: #eee;
+  font-family: 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
+}
+
+.debug-ui {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.presets {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.preset-btn {
+  background: #2a2a2a;
+  color: #ccc;
+  border: 1px solid #444;
+  padding: 0.3rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.preset-btn:hover {
+  background: #3a3a3a;
+}
+
+.preset-btn.active {
+  background: #4a90e2;
+  color: #fff;
+  border-color: #5aa0f2;
+}
+
+.scenarios {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.scenario-btn {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  background: #2a3a2a;
+  color: #8f8;
+  border: 1px solid #4a6a4a;
+  border-radius: 4px;
+}
+
+.scenario-btn:hover {
+  background: #3a4a3a;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.controls {
+  margin-bottom: 1rem;
+}
+
+.controls button {
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  background: #333;
+  color: #eee;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+
+.controls button:hover {
+  background: #444;
+}
+
+.controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.status {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background: #222;
+  border-radius: 4px;
+}
+
+.status-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.dig-power {
+  color: #4caf50;
+  font-weight: bold;
+}
+
+.dig-power-exhausted {
+  color: #ef5350;
+}
+
+.dig-power-warning {
+  font-size: 0.85em;
+  animation: blink 1s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.grid {
+  display: inline-block;
+  border: 2px solid #555;
+  background: #222;
+  margin-bottom: 1rem;
+}
+
+.row {
+  display: flex;
+}
+
+.cell {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  border: 1px solid #333;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+}
+
+.cell-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.overlap-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 0.9rem;
+  height: 0.9rem;
+  background: #ff5722;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: bold;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(25%, -25%);
+}
+
+.nutrient-indicator {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.nutrient-low {
+  background: #4caf50; /* 緑 - ニジリゴケ */
+}
+
+.nutrient-mid {
+  background: #5c6bc0; /* 青 - ガジガジムシ */
+}
+
+.nutrient-high {
+  background: #ef5350; /* 赤 - リザードマン */
+}
+
+.nutrient-legend {
+  margin-top: 0.5rem;
+}
+
+.nutrient-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.cell-wall {
+  background: #444;
+  color: #888;
+  cursor: default;
+}
+
+.cell-soil {
+  background: #3d2817;
+  color: #8b6914;
+}
+
+.cell-soil:hover {
+  background: #4d3827;
+}
+
+.cell-empty {
+  background: #1a1a1a;
+  cursor: default;
+}
+
+.nijirigoke-bud {
+  background: #3a3a00;
+  color: #cccc00;
+}
+
+.nijirigoke-flower {
+  background: #3a1a2a;
+  color: #ff69b4;
+  animation: flower-glow 1s ease-in-out infinite;
+}
+
+@keyframes flower-glow {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.nijirigoke-withered {
+  background: #2a2a2a;
+  color: #888888;
+}
+
+.monster-nijirigoke {
+  background: #1a4d1a;
+  color: #4caf50;
+}
+
+.monster-gajigajimushi {
+  background: #1a1a4d;
+  color: #5c6bc0;
+}
+
+.monster-lizardman {
+  background: #4d1a1a;
+  color: #ef5350;
+}
+
+.summon-hero-btn {
+  background: #4d4d1a;
+  color: #ffd700;
+  border: 1px solid #ffd700;
+  font-weight: bold;
+}
+
+.summon-hero-btn:hover {
+  background: #6a6a2a;
+}
+
+.hero-timer {
+  color: #88aaff;
+}
+
+.hero-timer-urgent {
+  color: #ff4444;
+  font-weight: bold;
+  animation: blink 0.5s ease-in-out infinite;
+}
+
+.placement-banner {
+  background: #4d1a4d;
+  color: #ff44ff;
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: bold;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  border: 2px solid #ff44ff;
+  animation: placement-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes placement-pulse {
+  0%, 100% { border-color: #ff44ff; }
+  50% { border-color: #aa22aa; }
+}
+
+.hero-cell {
+  background: #4d4d1a;
+  color: #ffd700;
+  font-weight: bold;
+}
+
+.hero-returning {
+  background: #4d3a1a;
+  color: #ff8c00;
+  animation: hero-blink 0.5s ease-in-out infinite;
+}
+
+@keyframes hero-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.entrance-cell {
+  background: #2a2a4d;
+  color: #88aaff;
+}
+
+.demon-lord-cell {
+  background: #4d1a4d;
+  color: #ff44ff;
+  font-weight: bold;
+}
+
+.game-over-banner {
+  background: #c62828;
+  color: #fff;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: bold;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  animation: game-over-pulse 1s ease-in-out infinite;
+}
+
+@keyframes game-over-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
+}
+
+.hero-status {
+  color: #ffd700;
+  margin-top: 0.25rem;
+}
+
+.hero-badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  background: #3a3a1a;
+  border: 1px solid #ffd700;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.nest-cell {
+  outline: 2px solid #ef5350;
+  outline-offset: -2px;
+  background-color: #2a1515 !important;
+}
+
+.cell-empty.nest-cell {
+  background-color: #2a1515 !important;
+}
+
+.legend {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.legend-item .cell {
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 0.9rem;
+  cursor: default;
+}
+
+.events {
+  background: #222;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.events h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+}
+
+.event-list {
+  font-family: monospace;
+  font-size: 0.85rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.event {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #333;
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,68 +1,33 @@
 <script setup lang="ts">
 import { ref, computed, onUnmounted } from 'vue'
 import {
-  createGameState,
-  initializeNutrients,
   tick,
   dig,
   getTotalNutrients,
   GameLoop,
   createSeededRandom,
   type GameState,
-  type Cell,
-  type Monster,
-  type MonsterType,
 } from './core'
-import { createDefaultConfig, type GameConfig } from './core/config'
+import { type GameConfig } from './core/config'
 import { GRID_PRESETS, type GridPresetKey } from './core/constants'
 import GridView from './components/GridView.vue'
 import { formatEvent } from './event-format'
 import { computeMonsterSummary } from './monster-summary'
-
-function createConfigForPreset(key: GridPresetKey): GameConfig {
-  const base = createDefaultConfig()
-  return {
-    ...base,
-    grid: {
-      ...base.grid,
-      defaultWidth: GRID_PRESETS[key].width,
-      defaultHeight: GRID_PRESETS[key].height,
-    },
-  }
-}
+import { createConfigForPreset, createInitialState } from './state-init'
+import { SCENARIOS, type Scenario } from './scenarios'
 
 const activePresetKey = ref<GridPresetKey>('small')
 const gameConfig = ref<GameConfig>(createConfigForPreset(activePresetKey.value))
-
-// Initialize game
-function createInitialState(): GameState {
-  const state = createGameState(
-    gameConfig.value.grid.defaultWidth,
-    gameConfig.value.grid.defaultHeight,
-    1.0,
-  )
-  const totalNutrients = 200
-  const { grid } = initializeNutrients(state.grid, totalNutrients, state.config)
-
-  // テスト用: エントリーポイント近くに高養分土を配置
-  grid[2][6].nutrientAmount = 20 // リザードマン用 (17以上)
-  grid[3][4].nutrientAmount = 12 // ガジガジムシ用 (10-16)
-
-  return {
-    ...state,
-    grid,
-    totalInitialNutrients: totalNutrients,
-  }
-}
-
-const gameState = ref<GameState>(createInitialState())
+const gameState = ref<GameState>(createInitialState(gameConfig.value))
 const events = ref<string[]>([])
 const isRunning = ref(false)
 const isPaused = ref(false)
 const isPlacingDemonLord = ref(false)
-const heroesTriggered = ref(false) // 勇者が呼ばれた（タイマー or 手動）
+const heroesTriggered = ref(false)
 
-// Game Loop
+let seededRandom: (() => number) | null = null
+let gameLoop: GameLoop | null = null
+
 function triggerHeroPhase() {
   heroesTriggered.value = true
   isPlacingDemonLord.value = true
@@ -71,12 +36,10 @@ function triggerHeroPhase() {
 }
 
 function executeTickWithEvents() {
-  // 制限時間到達 → 魔王配置フェーズへ
   if (!heroesTriggered.value && gameState.value.gameTime >= gameConfig.value.hero.spawnStartTick) {
     triggerHeroPhase()
     return
   }
-
   const randomFn = seededRandom || Math.random
   const result = tick(gameState.value, randomFn)
   result.events.forEach((e) => {
@@ -85,48 +48,31 @@ function executeTickWithEvents() {
   gameState.value = result.state
 }
 
-let gameLoop: GameLoop | null = null
-
 function initGameLoop() {
-  gameLoop = new GameLoop(() => {
-    executeTickWithEvents()
-  }, 500)
+  gameLoop = new GameLoop(() => executeTickWithEvents(), 500)
 }
 
 initGameLoop()
+onUnmounted(() => gameLoop?.stop())
 
-onUnmounted(() => {
-  gameLoop?.stop()
-})
-
-// Actions
 function handleCellClick(payload: { x: number; y: number }) {
   const { x, y } = payload
-  // Demon lord placement mode
   if (isPlacingDemonLord.value) {
     const cell = gameState.value.grid[y][x]
     if (cell.type !== 'empty') {
       events.value.unshift(`[Error] 魔王は空きセルにのみ配置できます`)
       return
     }
-    const currentTime = gameState.value.gameTime
     gameState.value = {
       ...gameState.value,
       demonLordPosition: { x, y },
-      heroSpawnConfig: {
-        ...gameState.value.heroSpawnConfig,
-        spawnStartTick: currentTime, // 即スポーン
-      },
+      heroSpawnConfig: { ...gameState.value.heroSpawnConfig, spawnStartTick: gameState.value.gameTime },
     }
     isPlacingDemonLord.value = false
     events.value.unshift(`[DEMON_LORD_PLACED] 魔王を (${x},${y}) に配置 — 勇者が来る!`)
-    // 自動再開
-    if (isRunning.value) {
-      resumeGame()
-    }
+    if (isRunning.value) resumeGame()
     return
   }
-
   const result = dig(gameState.value, { x, y })
   if ('error' in result) {
     events.value.unshift(`[Error] ${result.error}`)
@@ -174,8 +120,8 @@ function stopGame() {
 
 function handleReset() {
   stopGame()
-  seededRandom = null // 通常モードに戻す
-  gameState.value = createInitialState()
+  seededRandom = null
+  gameState.value = createInitialState(gameConfig.value)
   events.value = []
   heroesTriggered.value = false
   isPlacingDemonLord.value = false
@@ -184,7 +130,6 @@ function handleReset() {
 
 function selectPreset(key: GridPresetKey) {
   if (activePresetKey.value === key && !isRunning.value) {
-    // same preset, not running: still perform a reset so users get feedback
     handleReset()
     return
   }
@@ -192,237 +137,30 @@ function selectPreset(key: GridPresetKey) {
   activePresetKey.value = key
   gameConfig.value = createConfigForPreset(key)
   seededRandom = null
-  gameState.value = createInitialState()
+  gameState.value = createInitialState(gameConfig.value)
   events.value = []
   heroesTriggered.value = false
   isPlacingDemonLord.value = false
   initGameLoop()
 }
 
-// === デバッグシナリオ ===
-interface Scenario {
-  name: string
-  description: string
-  setup: () => void
-}
-
-const scenarios: Scenario[] = [
-  {
-    name: 'リザードマン産卵',
-    description: '巣あり・養分/life十分 → laying → 卵 → 孵化',
-    setup() {
-      stopGame()
-      const scenarioConfig = {
-        ...gameConfig.value,
-        grid: { ...gameConfig.value.grid, defaultWidth: 12, defaultHeight: 10 },
-      }
-      const grid = makeEmptyArena(scenarioConfig.grid.defaultWidth, scenarioConfig.grid.defaultHeight)
-      const state = makeState(grid, [
-        {
-          type: 'lizardman',
-          position: { x: 5, y: 4 },
-          nestPosition: { x: 5, y: 4 },
-          nestOrientation: 'horizontal' as const,
-          life: gameConfig.value.monsters.lizardman.layingLifeThreshold! + 20,
-          carryingNutrient: gameConfig.value.monsters.lizardman.layingNutrientThreshold! + 5,
-          phase: 'normal',
-        },
-      ])
-      loadScenario(state, 'リザードマン産卵: Startで観察')
-    },
-  },
-  {
-    name: 'ニジリゴケ変態',
-    description: '養分豊富 → bud → flower → withered → 繁殖',
-    setup() {
-      stopGame()
-      const scenarioConfig = {
-        ...gameConfig.value,
-        grid: { ...gameConfig.value.grid, defaultWidth: 12, defaultHeight: 10 },
-      }
-      const grid = makeEmptyArena(scenarioConfig.grid.defaultWidth, scenarioConfig.grid.defaultHeight)
-      // 周囲に養分付き土セルを配置（mobileは土からのみ吸収可能）
-      grid[3][5] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
-      grid[5][5] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
-      grid[4][4] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
-      grid[4][6] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
-      const state = makeState(grid, [
-        {
-          type: 'nijirigoke',
-          position: { x: 5, y: 4 },
-          life: gameConfig.value.monsters.nijirigoke.life,
-          carryingNutrient: 0,
-          phase: 'mobile',
-        },
-      ])
-      loadScenario(state, 'ニジリゴケ変態: bud→flower→withered→繁殖')
-    },
-  },
-  {
-    name: 'ガジガジムシ変態',
-    description: '養分あり → pupa → adult → 繁殖',
-    setup() {
-      stopGame()
-      const scenarioConfig = {
-        ...gameConfig.value,
-        grid: { ...gameConfig.value.grid, defaultWidth: 12, defaultHeight: 10 },
-      }
-      const grid = makeEmptyArena(scenarioConfig.grid.defaultWidth, scenarioConfig.grid.defaultHeight)
-      const state = makeState(grid, [
-        {
-          type: 'gajigajimushi',
-          position: { x: 5, y: 4 },
-          life: 25,
-          carryingNutrient: gameConfig.value.monsters.gajigajimushi.pupaNutrientThreshold! + 3,
-          phase: 'larva',
-        },
-      ])
-      loadScenario(state, 'ガジガジムシ変態: pupa→adult→繁殖')
-    },
-  },
-  {
-    name: '捕食チェーン',
-    description: 'リザードマン・ガジガジムシ・ニジリゴケが同エリアに',
-    setup() {
-      stopGame()
-      const scenarioConfig = {
-        ...gameConfig.value,
-        grid: { ...gameConfig.value.grid, defaultWidth: 12, defaultHeight: 10 },
-      }
-      const grid = makeEmptyArena(scenarioConfig.grid.defaultWidth, scenarioConfig.grid.defaultHeight)
-      const state = makeState(grid, [
-        {
-          type: 'lizardman',
-          position: { x: 5, y: 4 },
-          life: 60,
-          carryingNutrient: 3,
-          phase: 'normal',
-        },
-        {
-          type: 'gajigajimushi',
-          position: { x: 6, y: 4 },
-          life: 20,
-          carryingNutrient: 3,
-          phase: 'larva',
-        },
-        {
-          type: 'nijirigoke',
-          position: { x: 7, y: 4 },
-          life: 10,
-          carryingNutrient: 3,
-          phase: 'mobile',
-        },
-        {
-          type: 'nijirigoke',
-          position: { x: 4, y: 4 },
-          life: 10,
-          carryingNutrient: 3,
-          phase: 'mobile',
-        },
-      ])
-      loadScenario(state, '捕食チェーン: 3種が遭遇')
-    },
-  },
-]
-
-// シナリオ用ヘルパー
-function makeEmptyArena(width: number, height: number): Cell[][] {
-  const grid: Cell[][] = []
-  for (let y = 0; y < height; y++) {
-    const row: Cell[] = []
-    for (let x = 0; x < width; x++) {
-      if (x === 0 || x === width - 1 || y === 0 || y === height - 1) {
-        row.push({ type: 'wall', nutrientAmount: 0, magicAmount: 0 })
-      } else {
-        row.push({ type: 'empty', nutrientAmount: 0, magicAmount: 0 })
-      }
-    }
-    grid.push(row)
-  }
-  return grid
-}
-
-interface MonsterSetup {
-  type: MonsterType
-  position: { x: number; y: number }
-  nestPosition?: { x: number; y: number } | null
-  nestOrientation?: 'horizontal' | 'vertical' | null
-  life: number
-  carryingNutrient: number
-  phase: Monster['phase']
-}
-
-let monsterIdCounter = 0
-
-function makeState(grid: Cell[][], monsterSetups: MonsterSetup[]): GameState {
-  monsterIdCounter = 0
-  const monsters: Monster[] = monsterSetups.map((s) => {
-    monsterIdCounter++
-    const mConfig = gameConfig.value.monsters[s.type]
-    return {
-      id: `monster-${monsterIdCounter}`,
-      type: s.type,
-      position: { ...s.position },
-      direction: 'right' as const,
-      pattern: mConfig.pattern,
-      phase: s.phase,
-      phaseTickCounter: 0,
-      life: s.life,
-      maxLife: mConfig.life,
-      attack: mConfig.attack,
-      predationTargets: [...mConfig.predationTargets],
-      carryingNutrient: s.carryingNutrient,
-      nestPosition: s.nestPosition ? { ...s.nestPosition } : null,
-      nestOrientation: s.nestOrientation ?? null,
-    }
-  })
-
-  const heroDefaults = {
-    heroes: [] as import('./core/hero/types').HeroEntity[],
-    entrancePosition: { x: Math.floor(grid[0].length / 2), y: 0 },
-    demonLordPosition: null,
-    heroSpawnConfig: { partySize: 1, spawnStartTick: 100, spawnInterval: 10, heroesSpawned: 0 },
-    nextHeroId: 0,
-    isGameOver: false,
-  }
-
-  const totalNutrients = getTotalNutrients({
-    grid,
-    monsters,
-    totalInitialNutrients: 0,
-    digPower: 100,
-    gameTime: 0,
-    nextMonsterId: 0,
-    ...heroDefaults,
-    config: gameConfig.value,
-  })
-
-  return {
-    grid,
-    monsters,
-    totalInitialNutrients: totalNutrients,
-    digPower: 100,
-    gameTime: 0,
-    nextMonsterId: monsterIdCounter,
-    ...heroDefaults,
-    config: gameConfig.value,
-  }
-}
-
-function loadScenario(state: GameState, message: string) {
-  gameState.value = state
-  events.value = [`[SCENARIO] ${message}`]
+function loadScenario(scenario: Scenario) {
+  stopGame()
+  gameState.value = scenario.build(gameConfig.value)
+  events.value = [`[SCENARIO] ${scenario.message}`]
   seededRandom = createSeededRandom(42)
   initGameLoop()
 }
 
-// シナリオモードでは固定乱数を使う
-let seededRandom: (() => number) | null = null
+const scenarios = SCENARIOS.map((s) => ({
+  name: s.name,
+  description: s.description,
+  setup: () => loadScenario(s),
+}))
 
-// デバッグ: コンソールから window.__state でゲーム状態を確認可能
 ;(window as unknown as Record<string, unknown>).__state = gameState
-;(window as unknown as Record<string, unknown>).__monsters = computed(() => {
-  return gameState.value.monsters.map((m) => ({
+;(window as unknown as Record<string, unknown>).__monsters = computed(() =>
+  gameState.value.monsters.map((m) => ({
     id: m.id,
     type: m.type,
     phase: m.phase,
@@ -431,13 +169,11 @@ let seededRandom: (() => number) | null = null
     nutrient: m.carryingNutrient,
     nest: m.nestPosition ? `${m.nestPosition.x},${m.nestPosition.y}` : null,
     phaseTick: m.phaseTickCounter,
-  }))
-})
+  })),
+)
 
 const totalNutrients = computed(() => getTotalNutrients(gameState.value))
-
 const monsterSummary = computed(() => computeMonsterSummary(gameState.value.monsters))
-
 </script>
 
 <template>
@@ -587,430 +323,4 @@ const monsterSummary = computed(() => computeMonsterSummary(gameState.value.mons
   </div>
 </template>
 
-<style>
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  padding: 20px;
-  background: #1a1a1a;
-  color: #eee;
-  font-family: 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
-}
-
-.debug-ui {
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-.presets {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-bottom: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.preset-btn {
-  background: #2a2a2a;
-  color: #ccc;
-  border: 1px solid #444;
-  padding: 0.3rem 0.8rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.85rem;
-}
-
-.preset-btn:hover {
-  background: #3a3a3a;
-}
-
-.preset-btn.active {
-  background: #4a90e2;
-  color: #fff;
-  border-color: #5aa0f2;
-}
-
-.scenarios {
-  margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.scenario-btn {
-  padding: 0.4rem 0.8rem;
-  font-size: 0.85rem;
-  cursor: pointer;
-  background: #2a3a2a;
-  color: #8f8;
-  border: 1px solid #4a6a4a;
-  border-radius: 4px;
-}
-
-.scenario-btn:hover {
-  background: #3a4a3a;
-}
-
-h1 {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.controls {
-  margin-bottom: 1rem;
-}
-
-.controls button {
-  padding: 0.5rem 1rem;
-  margin-right: 0.5rem;
-  font-size: 1rem;
-  cursor: pointer;
-  background: #333;
-  color: #eee;
-  border: 1px solid #555;
-  border-radius: 4px;
-}
-
-.controls button:hover {
-  background: #444;
-}
-
-.controls button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.status {
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  background: #222;
-  border-radius: 4px;
-}
-
-.status-row {
-  display: flex;
-  gap: 2rem;
-  flex-wrap: wrap;
-}
-
-.dig-power {
-  color: #4caf50;
-  font-weight: bold;
-}
-
-.dig-power-exhausted {
-  color: #ef5350;
-}
-
-.dig-power-warning {
-  font-size: 0.85em;
-  animation: blink 1s ease-in-out infinite;
-}
-
-@keyframes blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-.grid {
-  display: inline-block;
-  border: 2px solid #555;
-  background: #222;
-  margin-bottom: 1rem;
-}
-
-.row {
-  display: flex;
-}
-
-.cell {
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.2rem;
-  border: 1px solid #333;
-  cursor: pointer;
-  user-select: none;
-  position: relative;
-}
-
-.cell-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-}
-
-.overlap-badge {
-  position: absolute;
-  top: 0;
-  right: 0;
-  min-width: 0.9rem;
-  height: 0.9rem;
-  background: #ff5722;
-  color: #fff;
-  font-size: 0.6rem;
-  font-weight: bold;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transform: translate(25%, -25%);
-}
-
-.nutrient-indicator {
-  position: absolute;
-  bottom: 2px;
-  right: 2px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-.nutrient-low {
-  background: #4caf50; /* 緑 - ニジリゴケ */
-}
-
-.nutrient-mid {
-  background: #5c6bc0; /* 青 - ガジガジムシ */
-}
-
-.nutrient-high {
-  background: #ef5350; /* 赤 - リザードマン */
-}
-
-.nutrient-legend {
-  margin-top: 0.5rem;
-}
-
-.nutrient-dot {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  vertical-align: middle;
-  margin-right: 4px;
-}
-
-.cell-wall {
-  background: #444;
-  color: #888;
-  cursor: default;
-}
-
-.cell-soil {
-  background: #3d2817;
-  color: #8b6914;
-}
-
-.cell-soil:hover {
-  background: #4d3827;
-}
-
-.cell-empty {
-  background: #1a1a1a;
-  cursor: default;
-}
-
-.nijirigoke-bud {
-  background: #3a3a00;
-  color: #cccc00;
-}
-
-.nijirigoke-flower {
-  background: #3a1a2a;
-  color: #ff69b4;
-  animation: flower-glow 1s ease-in-out infinite;
-}
-
-@keyframes flower-glow {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}
-
-.nijirigoke-withered {
-  background: #2a2a2a;
-  color: #888888;
-}
-
-.monster-nijirigoke {
-  background: #1a4d1a;
-  color: #4caf50;
-}
-
-.monster-gajigajimushi {
-  background: #1a1a4d;
-  color: #5c6bc0;
-}
-
-.monster-lizardman {
-  background: #4d1a1a;
-  color: #ef5350;
-}
-
-.summon-hero-btn {
-  background: #4d4d1a;
-  color: #ffd700;
-  border: 1px solid #ffd700;
-  font-weight: bold;
-}
-
-.summon-hero-btn:hover {
-  background: #6a6a2a;
-}
-
-.hero-timer {
-  color: #88aaff;
-}
-
-.hero-timer-urgent {
-  color: #ff4444;
-  font-weight: bold;
-  animation: blink 0.5s ease-in-out infinite;
-}
-
-.placement-banner {
-  background: #4d1a4d;
-  color: #ff44ff;
-  text-align: center;
-  font-size: 1.2rem;
-  font-weight: bold;
-  padding: 0.75rem;
-  margin-bottom: 1rem;
-  border-radius: 8px;
-  border: 2px solid #ff44ff;
-  animation: placement-pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes placement-pulse {
-  0%, 100% { border-color: #ff44ff; }
-  50% { border-color: #aa22aa; }
-}
-
-.hero-cell {
-  background: #4d4d1a;
-  color: #ffd700;
-  font-weight: bold;
-}
-
-.hero-returning {
-  background: #4d3a1a;
-  color: #ff8c00;
-  animation: hero-blink 0.5s ease-in-out infinite;
-}
-
-@keyframes hero-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
-}
-
-.entrance-cell {
-  background: #2a2a4d;
-  color: #88aaff;
-}
-
-.demon-lord-cell {
-  background: #4d1a4d;
-  color: #ff44ff;
-  font-weight: bold;
-}
-
-.game-over-banner {
-  background: #c62828;
-  color: #fff;
-  text-align: center;
-  font-size: 2rem;
-  font-weight: bold;
-  padding: 1rem;
-  margin-bottom: 1rem;
-  border-radius: 8px;
-  animation: game-over-pulse 1s ease-in-out infinite;
-}
-
-@keyframes game-over-pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.02); }
-}
-
-.hero-status {
-  color: #ffd700;
-  margin-top: 0.25rem;
-}
-
-.hero-badge {
-  display: inline-block;
-  margin-left: 0.5rem;
-  padding: 0.1rem 0.4rem;
-  background: #3a3a1a;
-  border: 1px solid #ffd700;
-  border-radius: 4px;
-  font-size: 0.8rem;
-}
-
-.nest-cell {
-  outline: 2px solid #ef5350;
-  outline-offset: -2px;
-  background-color: #2a1515 !important;
-}
-
-.cell-empty.nest-cell {
-  background-color: #2a1515 !important;
-}
-
-.legend {
-  margin-bottom: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.9rem;
-}
-
-.legend-item .cell {
-  width: 1.5rem;
-  height: 1.5rem;
-  font-size: 0.9rem;
-  cursor: default;
-}
-
-.events {
-  background: #222;
-  padding: 1rem;
-  border-radius: 4px;
-}
-
-.events h3 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1rem;
-}
-
-.event-list {
-  font-family: monospace;
-  font-size: 0.85rem;
-  max-height: 200px;
-  overflow-y: auto;
-}
-
-.event {
-  padding: 0.25rem 0;
-  border-bottom: 1px solid #333;
-}
-</style>
+<style src="./App.css"></style>

--- a/src/core/state-builders.test.ts
+++ b/src/core/state-builders.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { makeEmptyArena, makeScenarioState } from './state-builders'
+import { createDefaultConfig } from './config'
+
+describe('makeEmptyArena', () => {
+  it('produces walls on all four borders', () => {
+    const grid = makeEmptyArena(5, 4)
+    expect(grid.length).toBe(4)
+    expect(grid[0].length).toBe(5)
+    // top/bottom rows are all walls
+    grid[0].forEach((c) => expect(c.type).toBe('wall'))
+    grid[3].forEach((c) => expect(c.type).toBe('wall'))
+    // first/last column are walls
+    grid.forEach((row) => {
+      expect(row[0].type).toBe('wall')
+      expect(row[4].type).toBe('wall')
+    })
+  })
+
+  it('interior cells are empty (not soil)', () => {
+    const grid = makeEmptyArena(6, 5)
+    for (let y = 1; y < 4; y++) {
+      for (let x = 1; x < 5; x++) {
+        expect(grid[y][x].type).toBe('empty')
+      }
+    }
+  })
+
+  it('all cells start with zero nutrients and zero magic', () => {
+    const grid = makeEmptyArena(4, 4)
+    for (const row of grid) {
+      for (const c of row) {
+        expect(c.nutrientAmount).toBe(0)
+        expect(c.magicAmount).toBe(0)
+      }
+    }
+  })
+})
+
+describe('makeScenarioState', () => {
+  const config = createDefaultConfig()
+
+  it('returns empty monsters list when no setups given', () => {
+    const grid = makeEmptyArena(5, 5)
+    const state = makeScenarioState(grid, [], config)
+    expect(state.monsters).toEqual([])
+    expect(state.gameTime).toBe(0)
+    expect(state.isGameOver).toBe(false)
+  })
+
+  it('places monsters from setup with config-derived stats', () => {
+    const grid = makeEmptyArena(5, 5)
+    const state = makeScenarioState(
+      grid,
+      [
+        { type: 'nijirigoke', position: { x: 2, y: 2 }, life: 24, carryingNutrient: 3, phase: 'mobile' },
+      ],
+      config,
+    )
+    expect(state.monsters).toHaveLength(1)
+    const m = state.monsters[0]
+    expect(m.type).toBe('nijirigoke')
+    expect(m.position).toEqual({ x: 2, y: 2 })
+    expect(m.life).toBe(24)
+    expect(m.carryingNutrient).toBe(3)
+    expect(m.phase).toBe('mobile')
+    expect(m.maxLife).toBe(config.monsters.nijirigoke.life)
+    expect(m.attack).toBe(config.monsters.nijirigoke.attack)
+    expect(m.pattern).toBe(config.monsters.nijirigoke.pattern)
+  })
+
+  it('assigns sequential ids monster-1, monster-2, ...', () => {
+    const grid = makeEmptyArena(5, 5)
+    const state = makeScenarioState(
+      grid,
+      [
+        { type: 'nijirigoke', position: { x: 1, y: 1 }, life: 10, carryingNutrient: 0, phase: 'mobile' },
+        { type: 'gajigajimushi', position: { x: 2, y: 2 }, life: 20, carryingNutrient: 0, phase: 'larva' },
+      ],
+      config,
+    )
+    expect(state.monsters[0].id).toBe('monster-1')
+    expect(state.monsters[1].id).toBe('monster-2')
+    expect(state.nextMonsterId).toBe(2)
+  })
+
+  it('places entrance at top-center based on grid width', () => {
+    const grid = makeEmptyArena(10, 6)
+    const state = makeScenarioState(grid, [], config)
+    expect(state.entrancePosition).toEqual({ x: 5, y: 0 })
+  })
+
+  it('honors nestPosition and nestOrientation when given', () => {
+    const grid = makeEmptyArena(7, 7)
+    const state = makeScenarioState(
+      grid,
+      [
+        {
+          type: 'lizardman',
+          position: { x: 3, y: 3 },
+          nestPosition: { x: 3, y: 3 },
+          nestOrientation: 'horizontal',
+          life: 60,
+          carryingNutrient: 5,
+          phase: 'normal',
+        },
+      ],
+      config,
+    )
+    expect(state.monsters[0].nestPosition).toEqual({ x: 3, y: 3 })
+    expect(state.monsters[0].nestOrientation).toBe('horizontal')
+  })
+})

--- a/src/core/state-builders.ts
+++ b/src/core/state-builders.ts
@@ -1,0 +1,94 @@
+import type { Cell, GameState, Monster, MonsterType, MonsterPhase } from './types'
+import type { GameConfig } from './config'
+import { getTotalNutrients } from './nutrient'
+
+export interface MonsterSetup {
+  type: MonsterType
+  position: { x: number; y: number }
+  nestPosition?: { x: number; y: number } | null
+  nestOrientation?: 'horizontal' | 'vertical' | null
+  life: number
+  carryingNutrient: number
+  phase: MonsterPhase
+}
+
+/**
+ * Build a width×height grid where the borders are walls and the interior is empty.
+ * Used by debug scenarios that want a clean arena without random soil placement.
+ */
+export function makeEmptyArena(width: number, height: number): Cell[][] {
+  const grid: Cell[][] = []
+  for (let y = 0; y < height; y++) {
+    const row: Cell[] = []
+    for (let x = 0; x < width; x++) {
+      if (x === 0 || x === width - 1 || y === 0 || y === height - 1) {
+        row.push({ type: 'wall', nutrientAmount: 0, magicAmount: 0 })
+      } else {
+        row.push({ type: 'empty', nutrientAmount: 0, magicAmount: 0 })
+      }
+    }
+    grid.push(row)
+  }
+  return grid
+}
+
+/**
+ * Construct a GameState from a hand-crafted grid + monster setup list.
+ * Pure: takes config explicitly. Used by debug scenarios.
+ */
+export function makeScenarioState(
+  grid: Cell[][],
+  monsterSetups: MonsterSetup[],
+  config: GameConfig,
+): GameState {
+  const monsters: Monster[] = monsterSetups.map((s, idx) => {
+    const mConfig = config.monsters[s.type]
+    return {
+      id: `monster-${idx + 1}`,
+      type: s.type,
+      position: { ...s.position },
+      direction: 'right' as const,
+      pattern: mConfig.pattern,
+      phase: s.phase,
+      phaseTickCounter: 0,
+      life: s.life,
+      maxLife: mConfig.life,
+      attack: mConfig.attack,
+      predationTargets: [...mConfig.predationTargets],
+      carryingNutrient: s.carryingNutrient,
+      nestPosition: s.nestPosition ? { ...s.nestPosition } : null,
+      nestOrientation: s.nestOrientation ?? null,
+    }
+  })
+
+  const heroDefaults = {
+    heroes: [],
+    entrancePosition: { x: Math.floor(grid[0].length / 2), y: 0 },
+    demonLordPosition: null,
+    heroSpawnConfig: { partySize: 1, spawnStartTick: 100, spawnInterval: 10, heroesSpawned: 0 },
+    nextHeroId: 0,
+    isGameOver: false,
+  }
+
+  const totalNutrients = getTotalNutrients({
+    grid,
+    monsters,
+    totalInitialNutrients: 0,
+    digPower: 100,
+    gameTime: 0,
+    nextMonsterId: 0,
+    ...heroDefaults,
+    config,
+  })
+
+  return {
+    grid,
+    monsters,
+    totalInitialNutrients: totalNutrients,
+    digPower: 100,
+    gameTime: 0,
+    nextMonsterId: monsterSetups.length,
+    ...heroDefaults,
+    config,
+  }
+}

--- a/src/scenarios/index.test.ts
+++ b/src/scenarios/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { SCENARIOS } from './index'
+import { createDefaultConfig } from '../core/config'
+
+describe('SCENARIOS catalog', () => {
+  const config = createDefaultConfig()
+
+  it('contains 4 scenarios with distinct names', () => {
+    expect(SCENARIOS).toHaveLength(4)
+    const names = SCENARIOS.map((s) => s.name)
+    expect(new Set(names).size).toBe(4)
+  })
+
+  it.each(SCENARIOS)('scenario "$name" builds a valid 12x10 GameState', (scenario) => {
+    const state = scenario.build(config)
+    expect(state.grid.length).toBe(10)
+    expect(state.grid[0].length).toBe(12)
+    expect(state.gameTime).toBe(0)
+    expect(state.isGameOver).toBe(false)
+    expect(state.monsters.length).toBeGreaterThan(0)
+  })
+
+  it('リザードマン産卵: lizardman has nest and high life/nutrient', () => {
+    const s = SCENARIOS.find((x) => x.name === 'リザードマン産卵')!
+    const state = s.build(config)
+    const liz = state.monsters.find((m) => m.type === 'lizardman')!
+    expect(liz.nestPosition).not.toBeNull()
+    expect(liz.nestOrientation).toBe('horizontal')
+    expect(liz.life).toBeGreaterThan(config.monsters.lizardman.layingLifeThreshold!)
+  })
+
+  it('ニジリゴケ変態: places 4 nutrient-bearing soil cells around the nijirigoke', () => {
+    const s = SCENARIOS.find((x) => x.name === 'ニジリゴケ変態')!
+    const state = s.build(config)
+    const nutrientCells = state.grid.flat().filter((c) => c.type === 'soil' && c.nutrientAmount > 0)
+    expect(nutrientCells).toHaveLength(4)
+  })
+
+  it('捕食チェーン: spawns 4 monsters across all three types', () => {
+    const s = SCENARIOS.find((x) => x.name === '捕食チェーン')!
+    const state = s.build(config)
+    expect(state.monsters).toHaveLength(4)
+    const types = new Set(state.monsters.map((m) => m.type))
+    expect(types.has('lizardman')).toBe(true)
+    expect(types.has('gajigajimushi')).toBe(true)
+    expect(types.has('nijirigoke')).toBe(true)
+  })
+})

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -1,0 +1,116 @@
+import type { GameState } from '../core/types'
+import type { GameConfig } from '../core/config'
+import { makeEmptyArena, makeScenarioState } from '../core/state-builders'
+
+export interface Scenario {
+  name: string
+  description: string
+  message: string
+  /** Build the GameState for this scenario, given the active config. */
+  build(baseConfig: GameConfig): GameState
+}
+
+const SCENARIO_GRID_WIDTH = 12
+const SCENARIO_GRID_HEIGHT = 10
+
+function withScenarioGrid(base: GameConfig): GameConfig {
+  return {
+    ...base,
+    grid: { ...base.grid, defaultWidth: SCENARIO_GRID_WIDTH, defaultHeight: SCENARIO_GRID_HEIGHT },
+  }
+}
+
+export const SCENARIOS: Scenario[] = [
+  {
+    name: 'リザードマン産卵',
+    description: '巣あり・養分/life十分 → laying → 卵 → 孵化',
+    message: 'リザードマン産卵: Startで観察',
+    build(baseConfig) {
+      const config = withScenarioGrid(baseConfig)
+      const grid = makeEmptyArena(SCENARIO_GRID_WIDTH, SCENARIO_GRID_HEIGHT)
+      return makeScenarioState(
+        grid,
+        [
+          {
+            type: 'lizardman',
+            position: { x: 5, y: 4 },
+            nestPosition: { x: 5, y: 4 },
+            nestOrientation: 'horizontal',
+            life: config.monsters.lizardman.layingLifeThreshold! + 20,
+            carryingNutrient: config.monsters.lizardman.layingNutrientThreshold! + 5,
+            phase: 'normal',
+          },
+        ],
+        config,
+      )
+    },
+  },
+  {
+    name: 'ニジリゴケ変態',
+    description: '養分豊富 → bud → flower → withered → 繁殖',
+    message: 'ニジリゴケ変態: bud→flower→withered→繁殖',
+    build(baseConfig) {
+      const config = withScenarioGrid(baseConfig)
+      const grid = makeEmptyArena(SCENARIO_GRID_WIDTH, SCENARIO_GRID_HEIGHT)
+      // 周囲に養分付き土セルを配置（mobile は土からのみ吸収可能）
+      grid[3][5] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
+      grid[5][5] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
+      grid[4][4] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
+      grid[4][6] = { type: 'soil', nutrientAmount: 3, magicAmount: 0 }
+      return makeScenarioState(
+        grid,
+        [
+          {
+            type: 'nijirigoke',
+            position: { x: 5, y: 4 },
+            life: config.monsters.nijirigoke.life,
+            carryingNutrient: 0,
+            phase: 'mobile',
+          },
+        ],
+        config,
+      )
+    },
+  },
+  {
+    name: 'ガジガジムシ変態',
+    description: '養分あり → pupa → adult → 繁殖',
+    message: 'ガジガジムシ変態: pupa→adult→繁殖',
+    build(baseConfig) {
+      const config = withScenarioGrid(baseConfig)
+      const grid = makeEmptyArena(SCENARIO_GRID_WIDTH, SCENARIO_GRID_HEIGHT)
+      return makeScenarioState(
+        grid,
+        [
+          {
+            type: 'gajigajimushi',
+            position: { x: 5, y: 4 },
+            life: 25,
+            carryingNutrient: config.monsters.gajigajimushi.pupaNutrientThreshold! + 3,
+            phase: 'larva',
+          },
+        ],
+        config,
+      )
+    },
+  },
+  {
+    name: '捕食チェーン',
+    description: 'リザードマン・ガジガジムシ・ニジリゴケが同エリアに',
+    message: '捕食チェーン: 3種が遭遇',
+    build(baseConfig) {
+      const config = withScenarioGrid(baseConfig)
+      const grid = makeEmptyArena(SCENARIO_GRID_WIDTH, SCENARIO_GRID_HEIGHT)
+      return makeScenarioState(
+        grid,
+        [
+          { type: 'lizardman', position: { x: 5, y: 4 }, life: 60, carryingNutrient: 3, phase: 'normal' },
+          { type: 'gajigajimushi', position: { x: 6, y: 4 }, life: 20, carryingNutrient: 3, phase: 'larva' },
+          { type: 'nijirigoke', position: { x: 7, y: 4 }, life: 10, carryingNutrient: 3, phase: 'mobile' },
+          { type: 'nijirigoke', position: { x: 4, y: 4 }, life: 10, carryingNutrient: 3, phase: 'mobile' },
+        ],
+        config,
+      )
+    },
+  },
+]

--- a/src/state-init.test.ts
+++ b/src/state-init.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { createConfigForPreset, createInitialState } from './state-init'
+import { GRID_PRESETS } from './core/constants'
+
+describe('createConfigForPreset', () => {
+  it('small preset produces 10x8 grid dimensions', () => {
+    const config = createConfigForPreset('small')
+    expect(config.grid.defaultWidth).toBe(GRID_PRESETS.small.width)
+    expect(config.grid.defaultHeight).toBe(GRID_PRESETS.small.height)
+  })
+
+  it('large preset produces 30x40 grid dimensions', () => {
+    const config = createConfigForPreset('large')
+    expect(config.grid.defaultWidth).toBe(GRID_PRESETS.large.width)
+    expect(config.grid.defaultHeight).toBe(GRID_PRESETS.large.height)
+  })
+
+  it('preserves non-grid config from defaults', () => {
+    const config = createConfigForPreset('small')
+    expect(config.monsters.nijirigoke).toBeDefined()
+    expect(config.hero.life).toBeGreaterThan(0)
+  })
+})
+
+describe('createInitialState', () => {
+  it('builds GameState matching small preset dimensions', () => {
+    const config = createConfigForPreset('small')
+    const state = createInitialState(config)
+    expect(state.grid.length).toBe(GRID_PRESETS.small.height)
+    expect(state.grid[0].length).toBe(GRID_PRESETS.small.width)
+  })
+
+  it('seeds high-nutrient soil at (2,6) and (3,4) for small preset', () => {
+    const config = createConfigForPreset('small')
+    const state = createInitialState(config)
+    expect(state.grid[2][6].nutrientAmount).toBeGreaterThanOrEqual(17) // lizardman threshold
+    expect(state.grid[3][4].nutrientAmount).toBeGreaterThanOrEqual(10) // gaji threshold
+  })
+
+  it('reports totalInitialNutrients = 200', () => {
+    const config = createConfigForPreset('small')
+    const state = createInitialState(config)
+    expect(state.totalInitialNutrients).toBe(200)
+  })
+
+  it('builds GameState matching large preset dimensions', () => {
+    const config = createConfigForPreset('large')
+    const state = createInitialState(config)
+    expect(state.grid.length).toBe(GRID_PRESETS.large.height)
+    expect(state.grid[0].length).toBe(GRID_PRESETS.large.width)
+  })
+})

--- a/src/state-init.ts
+++ b/src/state-init.ts
@@ -1,0 +1,45 @@
+import { createGameState, initializeNutrients } from './core'
+import { createDefaultConfig, type GameConfig } from './core/config'
+import { GRID_PRESETS, type GridPresetKey } from './core/constants'
+import type { GameState } from './core/types'
+
+/**
+ * Build a GameConfig whose grid dimensions come from the named preset.
+ * All other config fields are inherited from createDefaultConfig().
+ */
+export function createConfigForPreset(key: GridPresetKey): GameConfig {
+  const base = createDefaultConfig()
+  return {
+    ...base,
+    grid: {
+      ...base.grid,
+      defaultWidth: GRID_PRESETS[key].width,
+      defaultHeight: GRID_PRESETS[key].height,
+    },
+  }
+}
+
+/**
+ * Build the default startup GameState for the given config.
+ * Initializes random nutrients then seeds two high-nutrient soil cells
+ * near the entrance so monsters can spawn quickly.
+ */
+export function createInitialState(config: GameConfig): GameState {
+  const state = createGameState(config.grid.defaultWidth, config.grid.defaultHeight, 1.0, {}, config)
+  const totalNutrients = 200
+  const { grid } = initializeNutrients(state.grid, totalNutrients, state.config)
+
+  // テスト用: エントリーポイント近くに高養分土を配置
+  if (grid.length > 3 && grid[2].length > 6) {
+    grid[2][6].nutrientAmount = 20 // リザードマン用 (17以上)
+  }
+  if (grid.length > 3 && grid[3].length > 4) {
+    grid[3][4].nutrientAmount = 12 // ガジガジムシ用 (10-16)
+  }
+
+  return {
+    ...state,
+    grid,
+    totalInitialNutrients: totalNutrients,
+  }
+}


### PR DESCRIPTION
Closes #57

## Summary

App.vue を **1016 → 326 行** (script 441 → 177) に圧縮。シナリオ定義 + grid/state 生成ヘルパー + CSS を別ファイルに切り出し、App.vue は配線とイベントハンドラに集中する形に。

## Acceptance criteria

- [x] **App.vue が 500 行未満** (326)
- [x] **理想は script 300 行程度** (177 — 大幅にクリア)
- [x] シナリオは App.vue から import するだけで定義は外部ファイル
- [x] makeEmptyArena / makeState 相当が core/ に存在し、シナリオから利用される
- [x] **#62 で整備された characterization test が green** (23 件、リファクタによる DOM 振る舞いの非破壊を保証)
- [x] 既存ユニットテストが green (391 件、was 368 → +23 新規)
- [ ] 既存 E2E green (CI で確認)

## Changes

### 新規ファイル

| ファイル | 内容 | テスト |
|---|---|---|
| `src/scenarios/index.ts` | 4 シナリオ (data + `build(config)`) | `scenarios/index.test.ts` (8 件) |
| `src/core/state-builders.ts` | `makeEmptyArena`, `makeScenarioState` (純) | `core/state-builders.test.ts` (8 件) |
| `src/state-init.ts` | `createConfigForPreset`, `createInitialState` | `state-init.test.ts` (7 件) |
| `src/App.css` | `<style>` 全 427 行を移動 | (CSS なのでテストなし) |

### App.vue 変更点

- 上記 4 ファイルから import に置換
- `<style>` を `<style src="./App.css">` 1 行に
- `loadScenario` を Scenario 受け取り型に変更し、`scenarios` 配列は `SCENARIOS.map(...)` で setup callback を bind

## Test plan

- [x] `pnpm test -- --run`: 391 件 pass
- [x] `pnpm lint`: クリーン
- [x] `pnpm exec vue-tsc -b`: 型エラー無し
- [ ] CI で E2E green
- [ ] merge 後ブラウザで動作確認 (small / large preset 切替、各シナリオ起動、勇者フェーズ)
