### PR TITLE
feat(ui): keyboard shortcuts + help modal (closes #53)

### DIFF
--- a/openspec/changes/keyboard-shortcuts/proposal.md
+++ b/openspec/changes/keyboard-shortcuts/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+デバッグ UI のすべての操作 (Start/Pause、Tick、Reset、preset 切替、シナリオ起動、勇者呼び出し) はマウスクリック専用で、頻繁に検証する開発者体験が悪かった。Issue #53 で「キーボード操作を追加」が要望され、合わせてバインディングを思い出せる仕組み (ヘルプモーダル) も必要。
+
+## What Changes
+
+### 新 capability: `keyboard-shortcuts`
+
+`useKeyboardShortcuts` composable を `src/composables/` に追加。各キーバインディングを optional handler として受け取り、`onMounted` で `window.keydown` listener を登録、`onUnmounted` で removeEventListener。
+
+サポートするバインディング:
+- `Space` → Start / Pause / Resume トグル
+- `T` → 1 tick
+- `R` → Reset
+- `1` / `2` → 小 / 大プリセット切替
+- `F1`〜`F4` → シナリオ 1〜4
+- `D` / `H` → 勇者を呼ぶ (魔王配置モード突入)
+- `?` → ヘルプモーダル開閉
+- `Escape` → ヘルプ閉じ → 配置モード解除
+
+### キーガード
+
+`document.activeElement` が `INPUT` / `TEXTAREA` / contenteditable のときは全ショートカット無効。テキスト入力との衝突を回避。
+
+### ヘルプモーダル
+
+`src/components/KeyboardHelpModal.vue` を新規追加。バインディング一覧テーブル + overlay クリック / × ボタン / Escape で close。`?` キーまたは「`?`」UI ボタン (Reset の隣) で open。
+
+### 既存 capability への影響
+
+`game-config` / `grid-size-preset` などの既存仕様は **変更なし**。本 change は UI 入力レイヤの純粋な追加 (キーボード経路) で、既存のクリック経路は維持。
+
+## Capabilities
+
+### New Capabilities
+
+- `keyboard-shortcuts`: グローバルキーボード入力のバインディング、ガード、ヘルプ提示の要件を定義する
+
+### Modified Capabilities
+
+なし
+
+## Impact
+
+- **コード (新規)**
+  - `src/composables/useKeyboardShortcuts.ts`
+  - `src/components/KeyboardHelpModal.vue`
+- **コード (変更)**
+  - `src/App.vue`: composable と modal を import + wire up (約 35 行追加)
+  - `src/App.css`: `.help-btn` 用スタイル (約 12 行追加)
+- **テスト**
+  - `src/composables/useKeyboardShortcuts.test.ts` (16 件)
+  - `src/components/KeyboardHelpModal.test.ts` (7 件)
+  - `src/App.test.ts` keyboard integration (5 件)
+- **ユーザー視点の変化**
+  - キーボードのみで全操作可能 (検証速度向上)
+  - 「`?`」ヘルプボタンが Reset の隣に追加 (バインディング離散性の解消)
+- **後続 change**
+  - 将来の機能追加時にバインディングを追加する場合は `useKeyboardShortcuts` の `ShortcutHandlers` interface を拡張する

--- a/openspec/changes/keyboard-shortcuts/specs/keyboard-shortcuts/spec.md
+++ b/openspec/changes/keyboard-shortcuts/specs/keyboard-shortcuts/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Keyboard shortcut bindings
+
+The system SHALL provide global keyboard shortcuts for primary debug-UI actions while a game session is open in the browser. Each shortcut SHALL invoke a single observable action.
+
+#### Scenario: Space toggles play state
+
+- **WHEN** the user presses `Space` and no input element is focused
+- **THEN** the system SHALL start the game if not running, pause it if running and not paused, resume it if paused
+
+#### Scenario: T advances one tick
+
+- **WHEN** the user presses `T` (case-insensitive) and no input element is focused
+- **THEN** the system SHALL execute exactly one tick of the simulation
+
+#### Scenario: R resets the game
+
+- **WHEN** the user presses `R` (case-insensitive) and no input element is focused
+- **THEN** the system SHALL reset to the initial state of the currently-active preset (events cleared, placement banner cleared, hero phase reset)
+
+#### Scenario: 1 / 2 select grid size preset
+
+- **WHEN** the user presses `1` and no input element is focused
+- **THEN** the system SHALL switch to the `small` preset
+- **WHEN** the user presses `2` and no input element is focused
+- **THEN** the system SHALL switch to the `large` preset
+
+#### Scenario: F1〜F4 trigger scenarios
+
+- **WHEN** the user presses `F1` and no input element is focused
+- **THEN** the system SHALL run scenario index 1 (current `SCENARIOS[0]`)
+- **AND** the same SHALL apply for `F2`, `F3`, `F4` mapped to scenarios 2, 3, 4
+- **AND** the browser default behavior for these keys SHALL be prevented
+
+#### Scenario: D / H summon the hero phase
+
+- **WHEN** the user presses `D` or `H` (case-insensitive) and no input element is focused, and the hero phase has not been triggered yet
+- **THEN** the system SHALL trigger the hero phase (open the demon-lord placement banner)
+- **WHEN** the hero phase has already been triggered
+- **THEN** the key SHALL be a no-op
+
+#### Scenario: ? toggles the help modal
+
+- **WHEN** the user presses `?` (Shift+/) and no input element is focused
+- **THEN** the system SHALL toggle the visibility of the keyboard-help modal
+
+#### Scenario: Escape closes help, then cancels placement
+
+- **WHEN** the user presses `Escape` and the help modal is open
+- **THEN** the system SHALL close the help modal
+- **WHEN** the help modal is closed AND demon-lord placement mode is active
+- **THEN** pressing `Escape` SHALL cancel placement mode (clear the placement banner)
+
+### Requirement: Input-focus suppression
+
+The system SHALL suppress all keyboard shortcuts while text input is in progress, so that typing does not interfere with shortcuts and vice versa.
+
+#### Scenario: Shortcut suppressed during INPUT focus
+
+- **WHEN** an element with tag name `INPUT` is the active document element AND the user presses any shortcut key
+- **THEN** no shortcut handler SHALL be invoked
+
+#### Scenario: Shortcut suppressed during TEXTAREA focus
+
+- **WHEN** an element with tag name `TEXTAREA` is the active document element AND the user presses any shortcut key
+- **THEN** no shortcut handler SHALL be invoked
+
+#### Scenario: Shortcut suppressed during contenteditable focus
+
+- **WHEN** an element with `isContentEditable === true` is the active document element AND the user presses any shortcut key
+- **THEN** no shortcut handler SHALL be invoked
+
+### Requirement: Lifecycle binding and unbinding
+
+The keyboard listener SHALL be installed when the component using `useKeyboardShortcuts` mounts, and SHALL be removed when the component unmounts, leaving no leaked event listeners.
+
+#### Scenario: Listener removed on unmount
+
+- **WHEN** a component using `useKeyboardShortcuts` is unmounted AND the user presses a shortcut key afterward
+- **THEN** the previously-registered handlers SHALL NOT be invoked
+
+### Requirement: Discoverable help modal
+
+The system SHALL expose a help modal listing every keyboard binding so users can discover them without external documentation.
+
+#### Scenario: Help button opens the modal
+
+- **WHEN** the user clicks the `?` button in the controls bar
+- **THEN** the keyboard-help modal SHALL appear
+
+#### Scenario: Modal closeable via overlay click
+
+- **WHEN** the help modal is open AND the user clicks the modal overlay (outside the modal body)
+- **THEN** the modal SHALL emit `close` and disappear
+
+#### Scenario: Modal closeable via close button
+
+- **WHEN** the help modal is open AND the user clicks the close button inside the modal header
+- **THEN** the modal SHALL emit `close` and disappear
+
+#### Scenario: Modal lists all bindings
+
+- **WHEN** the help modal is rendered
+- **THEN** it SHALL include rows for at least: `Space`, `T`, `R`, `1 / 2`, `F1〜F4`, `D / H`, `?`, `Escape`

--- a/openspec/changes/keyboard-shortcuts/tasks.md
+++ b/openspec/changes/keyboard-shortcuts/tasks.md
@@ -1,0 +1,30 @@
+## 1. composable 実装 (TDD)
+
+- [x] **1.1** `src/composables/useKeyboardShortcuts.ts` 新規作成
+- [x] **1.2** `src/composables/useKeyboardShortcuts.test.ts` 新規作成 (16 件)
+
+## 2. ヘルプモーダル
+
+- [x] **2.1** `src/components/KeyboardHelpModal.vue` 新規作成
+- [x] **2.2** `src/components/KeyboardHelpModal.test.ts` 新規作成 (7 件)
+
+## 3. App.vue 統合
+
+- [x] **3.1** `useKeyboardShortcuts` を setup() で呼び出し、各 handler を bind
+- [x] **3.2** `KeyboardHelpModal` を template に追加 (`isHelpOpen` で v-if)
+- [x] **3.3** `?` UI ボタン追加 (Reset の隣)
+- [x] **3.4** App.test.ts に integration test 追加 (5 件)
+- [x] **3.5** `src/App.css` に `.help-btn` スタイル追加
+
+## 4. 検証
+
+- [x] **4.1** `pnpm test -- --run` で全テスト pass (419 件)
+- [x] **4.2** `pnpm lint` で クリーン
+- [x] **4.3** `pnpm exec vue-tsc -b` で 型エラー無し
+
+## 5. spec / PR
+
+- [x] **5.1** delta spec (`openspec/changes/keyboard-shortcuts/specs/keyboard-shortcuts/spec.md`) 作成
+- [ ] **5.2** `openspec validate keyboard-shortcuts --strict` で pass
+- [ ] **5.3** PR 更新 (commit 追加 + push)
+- [ ] **5.4** CI green 確認 → manual merge → tag v0.6.0 → close #53 → archive

--- a/src/App.css
+++ b/src/App.css
@@ -282,6 +282,20 @@ h1 {
   background: #6a6a2a;
 }
 
+.help-btn {
+  background: #2a2a3a;
+  color: #aab;
+  border: 1px solid #557;
+  font-weight: bold;
+  min-width: 2.2rem;
+  padding: 0.5rem 0.6rem;
+  text-align: center;
+}
+
+.help-btn:hover {
+  background: #3a3a4a;
+}
+
 .hero-timer {
   color: #88aaff;
 }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -225,4 +225,61 @@ describe('App.vue (characterization before GridView extraction)', () => {
       expect(after).not.toBe(before)
     })
   })
+
+  describe('keyboard shortcuts', () => {
+    function dispatch(key: string) {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key }))
+    }
+
+    it('? opens the keyboard help modal', async () => {
+      const wrapper = mount(App, { attachTo: document.body })
+      expect(wrapper.find('.kbd-help-modal').exists()).toBe(false)
+      dispatch('?')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.kbd-help-modal').exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('Escape closes an open help modal', async () => {
+      const wrapper = mount(App, { attachTo: document.body })
+      dispatch('?')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.kbd-help-modal').exists()).toBe(true)
+      dispatch('Escape')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.kbd-help-modal').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('R triggers reset (clears placement banner if active)', async () => {
+      const wrapper = mount(App, { attachTo: document.body })
+      const summonBtn = wrapper.findAll('button').find((b) => b.text().includes('勇者を呼ぶ'))
+      await summonBtn!.trigger('click')
+      expect(wrapper.find('.placement-banner').exists()).toBe(true)
+      dispatch('r')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.placement-banner').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('2 switches to the large preset', async () => {
+      const wrapper = mount(App, { attachTo: document.body })
+      dispatch('2')
+      await wrapper.vm.$nextTick()
+      const rows = wrapper.findAll('.grid .row')
+      expect(rows.length).toBe(40)
+      wrapper.unmount()
+    })
+
+    it('Escape cancels demon-lord placement mode', async () => {
+      const wrapper = mount(App, { attachTo: document.body })
+      const summonBtn = wrapper.findAll('button').find((b) => b.text().includes('勇者を呼ぶ'))
+      await summonBtn!.trigger('click')
+      expect(wrapper.find('.placement-banner').exists()).toBe(true)
+      dispatch('Escape')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.placement-banner').exists()).toBe(false)
+      wrapper.unmount()
+    })
+  })
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,8 @@ import { formatEvent } from './event-format'
 import { computeMonsterSummary } from './monster-summary'
 import { createConfigForPreset, createInitialState } from './state-init'
 import { SCENARIOS, type Scenario } from './scenarios'
+import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
+import KeyboardHelpModal from './components/KeyboardHelpModal.vue'
 
 const activePresetKey = ref<GridPresetKey>('small')
 const gameConfig = ref<GameConfig>(createConfigForPreset(activePresetKey.value))
@@ -24,6 +26,7 @@ const isRunning = ref(false)
 const isPaused = ref(false)
 const isPlacingDemonLord = ref(false)
 const heroesTriggered = ref(false)
+const isHelpOpen = ref(false)
 
 let seededRandom: (() => number) | null = null
 let gameLoop: GameLoop | null = null
@@ -158,6 +161,35 @@ const scenarios = SCENARIOS.map((s) => ({
   setup: () => loadScenario(s),
 }))
 
+function togglePlay() {
+  if (!isRunning.value) startGame()
+  else if (isPaused.value) resumeGame()
+  else pauseGame()
+}
+
+useKeyboardShortcuts({
+  onTogglePlay: togglePlay,
+  onTick: handleTick,
+  onReset: handleReset,
+  onPresetSmall: () => selectPreset('small'),
+  onPresetLarge: () => selectPreset('large'),
+  onScenario: (idx) => scenarios[idx - 1]?.setup(),
+  onCallHero: () => {
+    if (!heroesTriggered.value) triggerHeroPhase()
+  },
+  onToggleHelp: () => {
+    isHelpOpen.value = !isHelpOpen.value
+  },
+  onEscape: () => {
+    if (isHelpOpen.value) {
+      isHelpOpen.value = false
+    } else if (isPlacingDemonLord.value) {
+      isPlacingDemonLord.value = false
+      events.value.unshift(`[CANCEL] 魔王配置をキャンセル`)
+    }
+  },
+})
+
 ;(window as unknown as Record<string, unknown>).__state = gameState
 ;(window as unknown as Record<string, unknown>).__monsters = computed(() =>
   gameState.value.monsters.map((m) => ({
@@ -221,7 +253,19 @@ const monsterSummary = computed(() => computeMonsterSummary(gameState.value.mons
       >
         勇者を呼ぶ
       </button>
+      <button
+        class="help-btn"
+        title="キーボードショートカット (?)"
+        @click="isHelpOpen = true"
+      >
+        ?
+      </button>
     </div>
+
+    <KeyboardHelpModal
+      :open="isHelpOpen"
+      @close="isHelpOpen = false"
+    />
 
     <div
       v-if="isPlacingDemonLord"

--- a/src/components/KeyboardHelpModal.test.ts
+++ b/src/components/KeyboardHelpModal.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KeyboardHelpModal from './KeyboardHelpModal.vue'
+
+describe('KeyboardHelpModal', () => {
+  it('renders nothing when open=false', () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: false } })
+    expect(wrapper.find('.kbd-help-modal').exists()).toBe(false)
+  })
+
+  it('renders modal when open=true', () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    expect(wrapper.find('.kbd-help-modal').exists()).toBe(true)
+  })
+
+  it('renders the bindings table with at least 8 rows', () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    const rows = wrapper.findAll('.kbd-help-table tbody tr')
+    expect(rows.length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('mentions Space, F1, Escape, ? in the bindings table', () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    const text = wrapper.text()
+    expect(text).toContain('Space')
+    expect(text).toContain('F1')
+    expect(text).toContain('Escape')
+    expect(text).toContain('?')
+  })
+
+  it('emits close when the X button is clicked', async () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    await wrapper.find('.kbd-help-close').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('emits close when the overlay is clicked', async () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    await wrapper.find('.kbd-help-overlay').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('does not emit close when the modal body is clicked (stopPropagation)', async () => {
+    const wrapper = mount(KeyboardHelpModal, { props: { open: true } })
+    await wrapper.find('.kbd-help-modal').trigger('click')
+    expect(wrapper.emitted('close')).toBeFalsy()
+  })
+})

--- a/src/components/KeyboardHelpModal.vue
+++ b/src/components/KeyboardHelpModal.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+defineProps<{ open: boolean }>()
+const emit = defineEmits<{ close: [] }>()
+
+const bindings = [
+  { key: 'Space', desc: 'Start / Pause' },
+  { key: 'T', desc: '1 tick 進める' },
+  { key: 'R', desc: 'リセット' },
+  { key: '1 / 2', desc: '小 / 大プリセット切替' },
+  { key: 'F1〜F4', desc: 'シナリオ 1〜4 起動' },
+  { key: 'D / H', desc: '勇者を呼ぶ (魔王配置モード)' },
+  { key: '?', desc: 'このヘルプの開閉' },
+  { key: 'Escape', desc: 'ヘルプを閉じる / 配置モード解除' },
+]
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="kbd-help-overlay"
+    @click="emit('close')"
+  >
+    <div
+      class="kbd-help-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kbd-help-title"
+      @click.stop
+    >
+      <div class="kbd-help-header">
+        <h2 id="kbd-help-title">
+          キーボードショートカット
+        </h2>
+        <button
+          class="kbd-help-close"
+          aria-label="閉じる"
+          @click="emit('close')"
+        >
+          ×
+        </button>
+      </div>
+      <table class="kbd-help-table">
+        <tbody>
+          <tr
+            v-for="b in bindings"
+            :key="b.key"
+          >
+            <td class="kbd-help-key">
+              <kbd>{{ b.key }}</kbd>
+            </td>
+            <td>{{ b.desc }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="kbd-help-note">
+        入力中 (input / textarea) はショートカット無効
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.kbd-help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.kbd-help-modal {
+  background: #2a2a2a;
+  color: #eee;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 1.5rem;
+  min-width: 320px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.kbd-help-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.kbd-help-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.kbd-help-close {
+  background: transparent;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 4px;
+  width: 2rem;
+  height: 2rem;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.kbd-help-close:hover {
+  background: #444;
+  color: #fff;
+}
+
+.kbd-help-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.kbd-help-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid #3a3a3a;
+}
+
+.kbd-help-key {
+  white-space: nowrap;
+}
+
+kbd {
+  background: #1a1a1a;
+  border: 1px solid #555;
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.kbd-help-note {
+  margin: 1rem 0 0;
+  font-size: 0.8rem;
+  color: #888;
+}
+</style>

--- a/src/composables/useKeyboardShortcuts.test.ts
+++ b/src/composables/useKeyboardShortcuts.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useKeyboardShortcuts, type ShortcutHandlers } from './useKeyboardShortcuts'
+
+function makeWrapper(handlers: ShortcutHandlers) {
+  const Comp = defineComponent({
+    setup() {
+      useKeyboardShortcuts(handlers)
+      return () => h('div')
+    },
+  })
+  return mount(Comp)
+}
+
+describe('useKeyboardShortcuts', () => {
+  let activeInputs: HTMLElement[] = []
+
+  beforeEach(() => {
+    activeInputs = []
+  })
+
+  afterEach(() => {
+    activeInputs.forEach((el) => el.remove())
+  })
+
+  function dispatch(key: string, opts: KeyboardEventInit = {}) {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key, ...opts }))
+  }
+
+  it('Space → onTogglePlay', () => {
+    const onTogglePlay = vi.fn()
+    makeWrapper({ onTogglePlay })
+    dispatch(' ')
+    expect(onTogglePlay).toHaveBeenCalledOnce()
+  })
+
+  it('T (lowercase) → onTick', () => {
+    const onTick = vi.fn()
+    makeWrapper({ onTick })
+    dispatch('t')
+    expect(onTick).toHaveBeenCalledOnce()
+  })
+
+  it('T (uppercase) → onTick', () => {
+    const onTick = vi.fn()
+    makeWrapper({ onTick })
+    dispatch('T')
+    expect(onTick).toHaveBeenCalledOnce()
+  })
+
+  it('R → onReset', () => {
+    const onReset = vi.fn()
+    makeWrapper({ onReset })
+    dispatch('r')
+    expect(onReset).toHaveBeenCalledOnce()
+  })
+
+  it('1 → onPresetSmall', () => {
+    const onPresetSmall = vi.fn()
+    makeWrapper({ onPresetSmall })
+    dispatch('1')
+    expect(onPresetSmall).toHaveBeenCalledOnce()
+  })
+
+  it('2 → onPresetLarge', () => {
+    const onPresetLarge = vi.fn()
+    makeWrapper({ onPresetLarge })
+    dispatch('2')
+    expect(onPresetLarge).toHaveBeenCalledOnce()
+  })
+
+  it('F1 → onScenario(1)', () => {
+    const onScenario = vi.fn()
+    makeWrapper({ onScenario })
+    dispatch('F1')
+    expect(onScenario).toHaveBeenCalledWith(1)
+  })
+
+  it('F4 → onScenario(4)', () => {
+    const onScenario = vi.fn()
+    makeWrapper({ onScenario })
+    dispatch('F4')
+    expect(onScenario).toHaveBeenCalledWith(4)
+  })
+
+  it('D → onCallHero', () => {
+    const onCallHero = vi.fn()
+    makeWrapper({ onCallHero })
+    dispatch('d')
+    expect(onCallHero).toHaveBeenCalledOnce()
+  })
+
+  it('H → onCallHero', () => {
+    const onCallHero = vi.fn()
+    makeWrapper({ onCallHero })
+    dispatch('h')
+    expect(onCallHero).toHaveBeenCalledOnce()
+  })
+
+  it('? (Shift+/) → onToggleHelp', () => {
+    const onToggleHelp = vi.fn()
+    makeWrapper({ onToggleHelp })
+    dispatch('?')
+    expect(onToggleHelp).toHaveBeenCalledOnce()
+  })
+
+  it('Escape → onEscape', () => {
+    const onEscape = vi.fn()
+    makeWrapper({ onEscape })
+    dispatch('Escape')
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
+  it('does not fire any handler when an INPUT element is focused', () => {
+    const onReset = vi.fn()
+    const onTogglePlay = vi.fn()
+    makeWrapper({ onReset, onTogglePlay })
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    activeInputs.push(input)
+    input.focus()
+    dispatch('r')
+    dispatch(' ')
+    expect(onReset).not.toHaveBeenCalled()
+    expect(onTogglePlay).not.toHaveBeenCalled()
+  })
+
+  it('does not fire any handler when a TEXTAREA element is focused', () => {
+    const onTick = vi.fn()
+    makeWrapper({ onTick })
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    activeInputs.push(ta)
+    ta.focus()
+    dispatch('t')
+    expect(onTick).not.toHaveBeenCalled()
+  })
+
+  it('removes the keydown listener on unmount', () => {
+    const onTogglePlay = vi.fn()
+    const wrapper = makeWrapper({ onTogglePlay })
+    wrapper.unmount()
+    dispatch(' ')
+    expect(onTogglePlay).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when handlers are omitted (handlers are optional)', () => {
+    expect(() => {
+      makeWrapper({})
+      dispatch(' ')
+      dispatch('r')
+      dispatch('F1')
+    }).not.toThrow()
+  })
+})

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,80 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export type ScenarioIndex = 1 | 2 | 3 | 4
+
+export interface ShortcutHandlers {
+  onTogglePlay?: () => void
+  onTick?: () => void
+  onReset?: () => void
+  onPresetSmall?: () => void
+  onPresetLarge?: () => void
+  onScenario?: (idx: ScenarioIndex) => void
+  onCallHero?: () => void
+  onToggleHelp?: () => void
+  onEscape?: () => void
+}
+
+function isInputFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') return true
+  if ((el as HTMLElement).isContentEditable) return true
+  return false
+}
+
+export function useKeyboardShortcuts(handlers: ShortcutHandlers): void {
+  function handler(e: KeyboardEvent) {
+    if (isInputFocused()) return
+    switch (e.key) {
+      case ' ':
+        handlers.onTogglePlay?.()
+        e.preventDefault()
+        break
+      case 't':
+      case 'T':
+        handlers.onTick?.()
+        break
+      case 'r':
+      case 'R':
+        handlers.onReset?.()
+        break
+      case '1':
+        handlers.onPresetSmall?.()
+        break
+      case '2':
+        handlers.onPresetLarge?.()
+        break
+      case 'd':
+      case 'D':
+      case 'h':
+      case 'H':
+        handlers.onCallHero?.()
+        break
+      case '?':
+        handlers.onToggleHelp?.()
+        break
+      case 'Escape':
+        handlers.onEscape?.()
+        break
+      case 'F1':
+        handlers.onScenario?.(1)
+        e.preventDefault()
+        break
+      case 'F2':
+        handlers.onScenario?.(2)
+        e.preventDefault()
+        break
+      case 'F3':
+        handlers.onScenario?.(3)
+        e.preventDefault()
+        break
+      case 'F4':
+        handlers.onScenario?.(4)
+        e.preventDefault()
+        break
+    }
+  }
+
+  onMounted(() => window.addEventListener('keydown', handler))
+  onUnmounted(() => window.removeEventListener('keydown', handler))
+}


### PR DESCRIPTION
Closes #53

## Summary

WebUI にキーボード操作とヘルプモーダルを追加。整理済みの App.vue (#57 後) に composable + 子コンポーネントとして wire up。

## Bindings

| キー | 動作 |
|---|---|
| `Space` | Start / Pause / Resume トグル |
| `T` | 1 tick 進める |
| `R` | リセット |
| `1` / `2` | 小 (10×8) / 大 (30×40) プリセット切替 |
| `F1` 〜 `F4` | シナリオ 1〜4 起動 |
| `D` / `H` | 勇者を呼ぶ (魔王配置モードへ) |
| `?` | キーボードヘルプモーダル開閉 |
| `Escape` | ヘルプモーダル閉じる → 配置モード解除 |

`<input>` / `<textarea>` / contenteditable にフォーカスがあるときはショートカット無効化。

## New files

- `src/composables/useKeyboardShortcuts.ts`: `keydown` をハンドラに dispatch する composable。`onMounted` で listener 追加、`onUnmounted` で removeEventListener。
- `src/components/KeyboardHelpModal.vue`: dialog 型 (overlay クリック / × ボタン / Escape で close)。

## Test plan

- [x] `pnpm test -- --run`: **419 件 pass** (was 391 → +28)
  - `useKeyboardShortcuts.test.ts`: 16 件
  - `KeyboardHelpModal.test.ts`: 7 件
  - `App.test.ts` keyboard integration: 5 件
- [x] `pnpm lint`: クリーン
- [x] `pnpm exec vue-tsc -b`: 型エラー無し
- [ ] CI で E2E green
- [ ] merge 後ブラウザで動作確認 (Space で start/pause、? で help、Escape で close、各 F キー)

## UI 変更

- 「Reset」ボタンの右に `?` ヘルプボタン (clickable discoverability)
